### PR TITLE
Ensure scheduled cleanup priming is covered by tests

### DIFF
--- a/.codex-state.json
+++ b/.codex-state.json
@@ -1,0 +1,7 @@
+{
+  "phase": 10,
+  "step": 10,
+  "percent": 100,
+  "last_task": "Finalized cron scheduling hardening and test coverage",
+  "notes": "Phase 10 complete"
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,20 @@
+name: Build Plugin Zip
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Prepare build
+        run: |
+          cd fp-performance-suite
+          zip -r ../build/fp-performance-suite.zip . -x '*.git*'
+      - uses: actions/upload-artifact@v3
+        with:
+          name: fp-performance-suite
+          path: build/fp-performance-suite.zip

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/vendor/
+/build/*.zip

--- a/fp-performance-suite/README.md
+++ b/fp-performance-suite/README.md
@@ -1,0 +1,47 @@
+# FP Performance Suite
+
+FP Performance Suite is a modular performance optimization plugin tailored for shared hosting environments. It combines caching, asset optimization, database cleanup, image conversion, logging controls, and provider-specific presets behind a unified dashboard.
+
+## Features
+
+- **Filesystem Page Cache** with safe controls and quick purge.
+- **Browser Cache Headers** with optional `.htaccess` automation (Apache aware).
+- **Asset Optimizer** for HTML minification, JS defer/async, DNS prefetch, preload management, heartbeat throttling, and emoji removal.
+- **WebP Converter** supporting Imagick and GD with lossy/lossless options, bulk processing, and coverage reporting.
+- **Database Cleaner** featuring dry-run reports, chunked operations, transient cleanup, and table optimization with confirmation.
+- **Realtime Log Center** to toggle `WP_DEBUG`, review tailing logs with filters, and restore wp-config backups.
+- **Preset Bundles** for Generale, IONOS, and Aruba shared hosting defaults with rollback capability.
+- **Technical SEO Performance Score** (0–100) with actionable suggestions and quick navigation.
+- **Import/Export** JSON settings, diagnostic tests, and multisite-aware options.
+- **Accessibility & Safety**: risk semaphores, PROCEDI confirmation for destructive actions, nonce/capability checks, and wp-config/.htaccess backups.
+
+## Requirements
+
+- WordPress 6.2+
+- PHP 7.4 – 8.3
+- Shared hosting compatible (no external services required)
+
+## Development
+
+1. Clone the repository into `wp-content/plugins/fp-performance-suite`.
+2. Run `composer dump-autoload` if you plan to use Composer autoloader (a lightweight PSR-4 autoloader ships in the plugin for convenience).
+3. Activate the plugin via the WordPress admin.
+
+### Testing
+
+Sample PHPUnit tests are available under `/tests`. Run them with:
+
+```bash
+phpunit --bootstrap tests/bootstrap.php tests
+```
+
+## Safety Notes
+
+- wp-config.php and .htaccess modifications are guarded with timestamped backups.
+- Database operations support dry-run mode by default and require PROCEDI confirmation for destructive batches.
+- WebP conversions keep originals unless explicitly disabled.
+- Settings include a “Safety mode” to constrain high-risk operations.
+
+## Uninstall
+
+Uninstalling the plugin removes all plugin-specific options.

--- a/fp-performance-suite/assets/admin.css
+++ b/fp-performance-suite/assets/admin.css
@@ -1,0 +1,167 @@
+:root {
+    --fp-bg: #f6f7fb;
+    --fp-card: #ffffff;
+    --fp-accent: #2d6cdf;
+    --fp-ok: #1f9d55;
+    --fp-warn: #f1b814;
+    --fp-danger: #d94452;
+    --fp-text: #1c1e21;
+}
+
+.fp-ps-wrap {
+    background: var(--fp-bg);
+    padding: 24px;
+}
+
+.fp-ps-header h1 {
+    margin: 0 0 16px;
+    color: var(--fp-text);
+    font-size: 28px;
+}
+
+.fp-ps-breadcrumbs ol {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    gap: 8px;
+    font-size: 13px;
+    color: #5a5f66;
+}
+
+.fp-ps-content {
+    display: grid;
+    gap: 24px;
+}
+
+.fp-ps-card {
+    background: var(--fp-card);
+    border-radius: 12px;
+    padding: 20px;
+    box-shadow: 0 8px 16px rgba(31, 35, 41, 0.05);
+}
+
+.fp-ps-card h2 {
+    margin-top: 0;
+    font-size: 20px;
+}
+
+.fp-ps-grid {
+    display: grid;
+    gap: 16px;
+}
+
+@media (min-width: 960px) {
+    .fp-ps-grid.two {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+    .fp-ps-grid.three {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+}
+
+.fp-ps-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 2px 8px;
+    border-radius: 16px;
+    font-size: 11px;
+    font-weight: 600;
+    color: #fff;
+    text-transform: uppercase;
+    letter-spacing: .04em;
+}
+
+.fp-ps-badge.green { background: var(--fp-ok); }
+.fp-ps-badge.amber { background: var(--fp-warn); }
+.fp-ps-badge.red { background: var(--fp-danger); }
+
+.fp-ps-toggle {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 12px 16px;
+    border: 1px solid #dbe1e7;
+    border-radius: 10px;
+    background: #fff;
+}
+
+.fp-ps-toggle .info {
+    display: flex;
+    flex-direction: column;
+}
+
+.fp-ps-toggle button,
+.fp-ps-toggle input[type="checkbox"] {
+    margin-left: 12px;
+}
+
+.fp-ps-tooltip {
+    position: relative;
+    cursor: help;
+}
+
+.fp-ps-tooltip span {
+    visibility: hidden;
+    position: absolute;
+    background: var(--fp-text);
+    color: #fff;
+    padding: 8px 12px;
+    border-radius: 8px;
+    font-size: 12px;
+    width: 240px;
+    bottom: 120%;
+    left: 50%;
+    transform: translateX(-50%);
+    opacity: 0;
+    transition: opacity 0.2s ease;
+    z-index: 10;
+}
+
+.fp-ps-tooltip:focus-within span,
+.fp-ps-tooltip:hover span {
+    visibility: visible;
+    opacity: 1;
+}
+
+.fp-ps-score {
+    font-size: 48px;
+    font-weight: 700;
+    color: var(--fp-accent);
+}
+
+.fp-ps-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.fp-ps-table th,
+.fp-ps-table td {
+    padding: 12px;
+    border-bottom: 1px solid #e5e8ee;
+    text-align: left;
+}
+
+.fp-ps-log-viewer {
+    background: #0d1117;
+    color: #e6edf3;
+    font-family: monospace;
+    font-size: 13px;
+    padding: 12px;
+    max-height: 400px;
+    overflow: auto;
+    border-radius: 8px;
+}
+
+.fp-ps-actions {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.fp-ps-actions button,
+.fp-ps-actions a.button {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}

--- a/fp-performance-suite/assets/admin.js
+++ b/fp-performance-suite/assets/admin.js
@@ -1,0 +1,91 @@
+(function () {
+    const { ajaxurl, fpPerfSuite = {} } = window;
+    const messages = fpPerfSuite.messages || {};
+
+    function request(url, method = 'GET', body = null, nonce = '') {
+        const headers = { 'X-WP-Nonce': nonce };
+        if (body) {
+            headers['Content-Type'] = 'application/json';
+        }
+        return fetch(url, {
+            method,
+            headers,
+            body: body ? JSON.stringify(body) : null,
+            credentials: 'same-origin'
+        }).then((response) => {
+            if (!response.ok) {
+                throw new Error('Request failed');
+            }
+            return response.json();
+        });
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+        document.querySelectorAll('[data-risk="red"]').forEach(function (toggle) {
+            toggle.addEventListener('change', function (event) {
+                if (!event.target.checked) {
+                    return;
+                }
+                const confirmation = window.prompt(fpPerfSuite.confirmLabel || 'Type PROCEDI to continue');
+                if (confirmation !== 'PROCEDI') {
+                    event.target.checked = false;
+                    alert(fpPerfSuite.cancelledLabel || 'Action cancelled');
+                }
+            });
+        });
+
+        const logContainer = document.querySelector('[data-fp-logs]');
+        if (logContainer) {
+            const nonce = logContainer.dataset.nonce;
+            const levelSelect = document.querySelector('[data-fp-log-filter]');
+            const searchInput = document.querySelector('[data-fp-log-search]');
+            const lines = logContainer.dataset.lines || '200';
+
+            function refreshLogs() {
+                const params = new URLSearchParams({ lines, level: levelSelect ? levelSelect.value : '', query: searchInput ? searchInput.value : '' });
+                request(fpPerfSuite.restUrl + 'logs/tail?' + params.toString(), 'GET', null, nonce)
+                    .then((response) => {
+                        logContainer.textContent = response.data.join('\n');
+                    })
+                    .catch(() => {
+                        logContainer.textContent = messages.logsError || 'Unable to load log data.';
+                    });
+            }
+
+            if (levelSelect) {
+                levelSelect.addEventListener('change', refreshLogs);
+            }
+            if (searchInput) {
+                searchInput.addEventListener('input', function () {
+                    window.clearTimeout(searchInput._fpDelay);
+                    searchInput._fpDelay = window.setTimeout(refreshLogs, 400);
+                });
+            }
+
+            window.setInterval(refreshLogs, 2000);
+            refreshLogs();
+        }
+
+        document.querySelectorAll('[data-fp-preset]').forEach(function (btn) {
+            btn.addEventListener('click', function (event) {
+                event.preventDefault();
+                const preset = btn.dataset.fpPreset;
+                const nonce = btn.dataset.fpNonce;
+                if (!preset) {
+                    return;
+                }
+                btn.disabled = true;
+                request(fpPerfSuite.restUrl + 'preset/apply', 'POST', { id: preset }, nonce)
+                    .then(() => {
+                        btn.dispatchEvent(new CustomEvent('fp:preset:applied', { bubbles: true }));
+                    })
+                    .catch(() => {
+                        alert(messages.presetError || 'Unable to apply preset.');
+                    })
+                    .finally(() => {
+                        btn.disabled = false;
+                    });
+            });
+        });
+    });
+})();

--- a/fp-performance-suite/bin/make-pot.php
+++ b/fp-performance-suite/bin/make-pot.php
@@ -1,0 +1,131 @@
+<?php
+declare(strict_types=1);
+
+$root = dirname(__DIR__);
+$source = $root;
+$potFile = $root . '/languages/fp-performance-suite.pot';
+
+$functions = [
+    '__',
+    '_e',
+    'esc_html__',
+    'esc_html_e',
+    'esc_attr__',
+    'esc_attr_e',
+    '_ex',
+    'esc_html_x',
+    'esc_attr_x',
+];
+
+$entries = [];
+
+$iterator = new RecursiveIteratorIterator(
+    new RecursiveDirectoryIterator($source, FilesystemIterator::SKIP_DOTS)
+);
+
+/** @var SplFileInfo $file */
+foreach ($iterator as $file) {
+    if ($file->isDir()) {
+        continue;
+    }
+    $ext = strtolower($file->getExtension());
+    if (!in_array($ext, ['php', 'inc'], true)) {
+        continue;
+    }
+
+    $code = file_get_contents($file->getPathname());
+    if ($code === false) {
+        continue;
+    }
+
+    $tokens = token_get_all($code);
+    $length = count($tokens);
+    for ($i = 0; $i < $length; $i++) {
+        $token = $tokens[$i];
+        if (!is_array($token)) {
+            continue;
+        }
+        [$id, $text, $line] = $token;
+        if ($id !== T_STRING || !in_array($text, $functions, true)) {
+            continue;
+        }
+
+        $prev = $tokens[$i - 1] ?? null;
+        if ($prev === '\\') {
+            continue;
+        }
+        if (is_array($prev) && in_array($prev[0], [T_OBJECT_OPERATOR, T_DOUBLE_COLON], true)) {
+            continue;
+        }
+
+        $j = $i + 1;
+        while ($j < $length && (!is_string($tokens[$j]) || $tokens[$j] !== '(')) {
+            $j++;
+        }
+        if ($j >= $length) {
+            continue;
+        }
+        $j++;
+        while ($j < $length && is_array($tokens[$j]) && $tokens[$j][0] === T_WHITESPACE) {
+            $j++;
+        }
+        if ($j >= $length) {
+            continue;
+        }
+        $argToken = $tokens[$j];
+        if (!is_array($argToken) || $argToken[0] !== T_CONSTANT_ENCAPSED_STRING) {
+            continue;
+        }
+        $raw = $argToken[1];
+        $msgid = stripcslashes(substr($raw, 1, -1));
+        if ($msgid === '') {
+            continue;
+        }
+
+        $relative = str_replace($root . '/', '', $file->getPathname());
+        $entries[$msgid]['references'][] = $relative . ':' . $line;
+    }
+}
+
+ksort($entries, SORT_STRING);
+
+$header = [
+    'msgid ""',
+    'msgstr ""',
+    '"Project-Id-Version: FP Performance Suite 1.0.0\\n"',
+    '"Report-Msgid-Bugs-To: \n"',
+    '"POT-Creation-Date: ' . gmdate('Y-m-d H:i:s') . ' +0000\\n"',
+    '"MIME-Version: 1.0\\n"',
+    '"Content-Type: text/plain; charset=UTF-8\\n"',
+    '"Content-Transfer-Encoding: 8bit\\n"',
+    '"X-Generator: make-pot.php\\n"',
+    '"X-Domain: fp-performance-suite\\n"',
+    '',
+];
+
+$contents = implode("\n", $header);
+
+foreach ($entries as $msgid => $data) {
+    $references = array_unique($data['references'] ?? []);
+    if ($references) {
+        $contents .= '#: ' . implode(' ', $references) . "\n";
+    }
+    $contents .= 'msgid ' . format_po_string($msgid);
+    $contents .= 'msgstr ""' . "\n\n";
+}
+
+file_put_contents($potFile, $contents);
+
+function format_po_string(string $text): string
+{
+    if ($text === '') {
+        return "\"\"\n";
+    }
+    $escaped = str_replace(
+        ["\\", "\"", "\t", "\r"],
+        ["\\\\", "\\\"", "\\t", "\\r"],
+        $text
+    );
+    $escaped = str_replace("\n", "\\n\"\n\"", $escaped);
+    return '"' . $escaped . '"' . "\n";
+}

--- a/fp-performance-suite/composer.json
+++ b/fp-performance-suite/composer.json
@@ -1,0 +1,11 @@
+{
+    "name": "fp/performance-suite",
+    "description": "FP Performance Suite WordPress plugin",
+    "type": "wordpress-plugin",
+    "require": {},
+    "autoload": {
+        "psr-4": {
+            "FP\\PerfSuite\\": "src/"
+        }
+    }
+}

--- a/fp-performance-suite/fp-performance-suite.php
+++ b/fp-performance-suite/fp-performance-suite.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Plugin Name: FP Performance Suite
+ * Description: Optimize performance for shared hosting with modular services.
+ * Version: 1.0.0
+ * Author: FP Engineering
+ * Text Domain: fp-performance-suite
+ * Domain Path: /languages
+ */
+
+defined('ABSPATH') || exit;
+
+$autoload = __DIR__ . '/vendor/autoload.php';
+if (file_exists($autoload)) {
+    require_once $autoload;
+} else {
+    spl_autoload_register(static function ($class) {
+        if (strpos($class, 'FP\\PerfSuite\\') !== 0) {
+            return;
+        }
+        $path = __DIR__ . '/src/' . str_replace('FP\\PerfSuite\\', '', $class) . '.php';
+        $path = str_replace('\\', '/', $path);
+        if (file_exists($path)) {
+            require_once $path;
+        }
+    });
+}
+
+define('FP_PERF_SUITE_VERSION', '1.0.0');
+define('FP_PERF_SUITE_DIR', __DIR__);
+
+defined('FP_PERF_SUITE_FILE') || define('FP_PERF_SUITE_FILE', __FILE__);
+
+use FP\PerfSuite\Plugin;
+
+register_activation_hook(__FILE__, [Plugin::class, 'onActivate']);
+register_deactivation_hook(__FILE__, [Plugin::class, 'onDeactivate']);
+
+if (function_exists('add_action')) {
+    add_action('plugins_loaded', static function () {
+        Plugin::init();
+    });
+}

--- a/fp-performance-suite/languages/fp-performance-suite.pot
+++ b/fp-performance-suite/languages/fp-performance-suite.pot
@@ -1,0 +1,834 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: FP Performance Suite 1.0.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-09-30 19:11:16 +0000\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: make-pot.php\n"
+"X-Domain: fp-performance-suite\n"
+#: src/Admin/Pages/Media.php:131
+msgid "%1$d items processed out of %2$d."
+msgstr ""
+
+#: src/Admin/Pages/Cache.php:134
+msgid ".htaccess rules"
+msgstr ""
+
+#: src/Admin/Pages/Settings.php:71
+msgid "Access Control"
+msgstr ""
+
+#: src/Admin/Assets.php:36
+msgid "Action cancelled"
+msgstr ""
+
+#: src/Services/Score/Scorer.php:157
+msgid "Activate browser caching headers for static assets."
+msgstr ""
+
+#: src/Admin/Pages/Presets.php:61
+msgid "Active"
+msgstr ""
+
+#: src/Admin/Pages/Dashboard.php:88 src/Admin/Pages/Dashboard.php:149
+msgid "Active Optimizations"
+msgstr ""
+
+#: src/Services/Score/Scorer.php:241
+msgid "Add critical CSS placeholder for above-the-fold styles."
+msgstr ""
+
+#: src/Admin/Pages/Cache.php:121
+msgid "Adds Cache-Control/Expires headers for static files."
+msgstr ""
+
+#: src/Admin/Pages/Settings.php:77
+msgid "Administrator"
+msgstr ""
+
+#: src/Admin/Pages/Logs.php:117
+msgid "All"
+msgstr ""
+
+#: src/Admin/Pages/Media.php:96 src/Admin/Pages/Media.php:103 src/Admin/Pages/Assets.php:84 src/Admin/Pages/Assets.php:91 src/Admin/Pages/Assets.php:98 src/Admin/Pages/Logs.php:94
+msgid "Amber"
+msgstr ""
+
+#: src/Admin/Pages/Presets.php:71
+msgid "Apply Preset"
+msgstr ""
+
+#: src/Services/Presets/Manager.php:63
+msgid "Aruba"
+msgstr ""
+
+#: src/Services/Score/Scorer.php:64
+msgid "Asset optimization"
+msgstr ""
+
+#: src/Admin/Pages/Assets.php:69
+msgid "Asset settings saved."
+msgstr ""
+
+#: src/Admin/Pages/Assets.php:47 src/Admin/Menu.php:53
+msgid "Assets"
+msgstr ""
+
+#: src/Admin/Pages/Assets.php:30
+msgid "Assets Optimization"
+msgstr ""
+
+#: src/Admin/Pages/Assets.php:97
+msgid "Async JavaScript"
+msgstr ""
+
+#: src/Admin/Pages/Database.php:80
+msgid "Auto drafts"
+msgstr ""
+
+#: src/Admin/Pages/Database.php:108
+msgid "Batch size"
+msgstr ""
+
+#: src/Admin/Pages/Cache.php:114
+msgid "Browser Cache Headers"
+msgstr ""
+
+#: src/Services/Score/Scorer.php:50 src/Admin/Pages/Tools.php:101
+msgid "Browser cache headers"
+msgstr ""
+
+#: src/Services/Score/Scorer.php:126
+msgid "Browser cache headers applied"
+msgstr ""
+
+#: src/Admin/Pages/Cache.php:72
+msgid "Browser cache settings saved."
+msgstr ""
+
+#: src/Admin/Pages/Media.php:114
+msgid "Bulk Convert Library"
+msgstr ""
+
+#: src/Admin/Pages/Dashboard.php:107
+msgid "Bulk WebP Convert"
+msgstr ""
+
+#: src/Admin/Pages/Media.php:67
+msgid "Bulk conversion completed."
+msgstr ""
+
+#: src/Admin/Pages/Cache.php:45 src/Admin/Menu.php:52
+msgid "Cache"
+msgstr ""
+
+#: src/Admin/Pages/Cache.php:28
+msgid "Cache Optimization"
+msgstr ""
+
+#: src/Admin/Pages/Cache.php:103
+msgid "Cache lifetime (seconds)"
+msgstr ""
+
+#: src/Admin/Pages/Cache.php:126
+msgid "Cache-Control"
+msgstr ""
+
+#: src/Admin/Pages/Database.php:119
+msgid "Cleanup Tools"
+msgstr ""
+
+#: src/Admin/Pages/Database.php:69
+msgid "Cleanup completed."
+msgstr ""
+
+#: src/Admin/Pages/Database.php:100
+msgid "Cleanup schedule"
+msgstr ""
+
+#: src/Admin/Pages/Cache.php:108
+msgid "Clear Cache"
+msgstr ""
+
+#: src/Admin/Pages/Assets.php:104
+msgid "Combine CSS files"
+msgstr ""
+
+#: src/Admin/Pages/Assets.php:111
+msgid "Combine JS files"
+msgstr ""
+
+#: src/Services/Assets/Optimizer.php:216
+msgid "Combining scripts may break complex setups. Proceed with caution."
+msgstr ""
+
+#: src/Admin/Pages/Settings.php:46
+msgid "Configuration"
+msgstr ""
+
+#: src/Admin/Pages/Dashboard.php:96
+msgid "Configure Cache"
+msgstr ""
+
+#: src/Services/Score/Scorer.php:181
+msgid "Consider deferring non-critical JavaScript."
+msgstr ""
+
+#: src/Services/Score/Scorer.php:99
+msgid "Critical CSS"
+msgstr ""
+
+#: src/Admin/Pages/Settings.php:89
+msgid "Critical CSS placeholder"
+msgstr ""
+
+#: src/Admin/Pages/Media.php:111
+msgid "Current WebP coverage: %s%%"
+msgstr ""
+
+#: src/Admin/Pages/Cache.php:110
+msgid "Current cached files: %d"
+msgstr ""
+
+#: src/Admin/Pages/Database.php:115
+msgid "Current overhead: %s MB"
+msgstr ""
+
+#: src/Admin/Pages/Dashboard.php:65
+msgid "Custom"
+msgstr ""
+
+#: src/Admin/Pages/Assets.php:128
+msgid "DNS Prefetch domains (one per line)"
+msgstr ""
+
+#: src/Admin/Pages/Dashboard.php:55 src/Admin/Menu.php:51
+msgid "Dashboard"
+msgstr ""
+
+#: src/Admin/Pages/Database.php:48 src/Admin/Menu.php:55
+msgid "Database"
+msgstr ""
+
+#: src/Admin/Pages/Dashboard.php:106
+msgid "Database Cleanup"
+msgstr ""
+
+#: src/Admin/Pages/Database.php:31
+msgid "Database Optimization"
+msgstr ""
+
+#: src/Services/Score/Scorer.php:78
+msgid "Database health"
+msgstr ""
+
+#: src/Admin/Pages/Database.php:63
+msgid "Database settings updated."
+msgstr ""
+
+#: src/Admin/Pages/Logs.php:80
+msgid "Debug Toggles"
+msgstr ""
+
+#: src/Admin/Pages/Logs.php:57
+msgid "Debug configuration updated."
+msgstr ""
+
+#: src/Services/Score/Scorer.php:130
+msgid "Defer JS active"
+msgstr ""
+
+#: src/Admin/Pages/Assets.php:90
+msgid "Defer JavaScript"
+msgstr ""
+
+#: src/Services/Assets/Optimizer.php:215
+msgid "Defers non-critical JavaScript to speed rendering."
+msgstr ""
+
+#: src/Admin/Pages/Database.php:150
+msgid "Deleted"
+msgstr ""
+
+#: src/Admin/Pages/Assets.php:78
+msgid "Delivery"
+msgstr ""
+
+#: src/Admin/Pages/Tools.php:126
+msgid "Diagnostics"
+msgstr ""
+
+#: src/Services/Score/Scorer.php:232
+msgid "Disable emojis and embeds to reduce front-end requests."
+msgstr ""
+
+#: src/Admin/Pages/Tools.php:100
+msgid "Disabled"
+msgstr ""
+
+#: src/Services/Assets/Optimizer.php:214
+msgid "Disables emoji scripts to save requests."
+msgstr ""
+
+#: src/Admin/Pages/Database.php:136
+msgid "Dry run"
+msgstr ""
+
+#: src/Admin/Pages/Database.php:69
+msgid "Dry run completed."
+msgstr ""
+
+#: src/Admin/Pages/Settings.php:78
+msgid "Editor"
+msgstr ""
+
+#: src/Services/Score/Scorer.php:92
+msgid "Emoji & embeds"
+msgstr ""
+
+#: src/Services/Score/Scorer.php:133
+msgid "Emoji scripts removed"
+msgstr ""
+
+#: src/Services/Score/Scorer.php:148
+msgid "Enable GZIP or Brotli compression via server configuration."
+msgstr ""
+
+#: src/Services/Score/Scorer.php:176
+msgid "Enable HTML/CSS minification to reduce payload."
+msgstr ""
+
+#: src/Admin/Pages/Logs.php:86
+msgid "Enable WP_DEBUG"
+msgstr ""
+
+#: src/Services/Score/Scorer.php:196
+msgid "Enable WebP conversion to serve modern formats."
+msgstr ""
+
+#: src/Admin/Pages/Media.php:84
+msgid "Enable WebP on upload"
+msgstr ""
+
+#: src/Admin/Pages/Logs.php:93
+msgid "Enable debug.log"
+msgstr ""
+
+#: src/Admin/Pages/Cache.php:120
+msgid "Enable headers"
+msgstr ""
+
+#: src/Admin/Pages/Cache.php:97
+msgid "Enable page cache"
+msgstr ""
+
+#: src/Services/Score/Scorer.php:165
+msgid "Enable page caching to store HTML output on disk."
+msgstr ""
+
+#: src/Admin/Pages/Logs.php:120
+msgid "Error"
+msgstr ""
+
+#: src/Admin/Pages/Database.php:141
+msgid "Execute Cleanup"
+msgstr ""
+
+#: src/Admin/Pages/Database.php:83
+msgid "Expired transients"
+msgstr ""
+
+#: src/Admin/Pages/Cache.php:130
+msgid "Expires header"
+msgstr ""
+
+#: src/Admin/Pages/Dashboard.php:109
+msgid "Export CSV Summary"
+msgstr ""
+
+#: src/Admin/Pages/Tools.php:111
+msgid "Export Settings"
+msgstr ""
+
+#: src/Admin/Menu.php:43
+msgid "FP Performance"
+msgstr ""
+
+#: src/Admin/Pages/Dashboard.php:38 src/Admin/Menu.php:42
+msgid "FP Performance Suite"
+msgstr ""
+
+#: src/Admin/Pages/Logs.php:113
+msgid "Filtered tail of debug.log with live updates every 2 seconds."
+msgstr ""
+
+#: src/Admin/Pages/Database.php:149
+msgid "Found"
+msgstr ""
+
+#: src/Services/Score/Scorer.php:43
+msgid "GZIP/Brotli"
+msgstr ""
+
+#: src/Services/Presets/Manager.php:41
+msgid "Generale"
+msgstr ""
+
+#: src/Admin/Pages/Settings.php:84 src/Admin/Pages/Media.php:85 src/Admin/Pages/Assets.php:119
+msgid "Green"
+msgstr ""
+
+#: src/Admin/Pages/Assets.php:124
+msgid "Heartbeat interval (seconds)"
+msgstr ""
+
+#: src/Services/Score/Scorer.php:85
+msgid "Heartbeat throttling"
+msgstr ""
+
+#: src/Admin/Pages/Dashboard.php:85
+msgid "Higher score indicates better technical readiness for shared hosting."
+msgstr ""
+
+#: src/Services/Presets/Manager.php:52
+msgid "IONOS"
+msgstr ""
+
+#: src/Admin/Pages/Tools.php:122
+msgid "Import JSON"
+msgstr ""
+
+#: src/Admin/Pages/Tools.php:115
+msgid "Import Settings"
+msgstr ""
+
+#: src/Services/Score/Scorer.php:219
+msgid "Increase admin heartbeat interval to reduce CPU load."
+msgstr ""
+
+#: src/Admin/Pages/Tools.php:87
+msgid "Invalid JSON payload."
+msgstr ""
+
+#: src/Admin/Pages/Dashboard.php:113
+msgid "Issues & Suggestions"
+msgstr ""
+
+#: src/Admin/Pages/Media.php:119
+msgid "Items per batch"
+msgstr ""
+
+#: src/Admin/Pages/Media.php:95
+msgid "Keep original files"
+msgstr ""
+
+#: src/Admin/Pages/Logs.php:124
+msgid "Keyword"
+msgstr ""
+
+#: src/Admin/Pages/Database.php:116
+msgid "Last automated cleanup: %s"
+msgstr ""
+
+#: src/Admin/Pages/Logs.php:115
+msgid "Level"
+msgstr ""
+
+#: src/Services/Score/Scorer.php:259
+msgid "Log file is noisy. Resolve errors and clear debug.log."
+msgstr ""
+
+#: src/Admin/Pages/Logs.php:108
+msgid "Log file:"
+msgstr ""
+
+#: src/Admin/Pages/Logs.php:43 src/Admin/Menu.php:57
+msgid "Logs"
+msgstr ""
+
+#: src/Services/Score/Scorer.php:106
+msgid "Logs hygiene"
+msgstr ""
+
+#: src/Admin/Pages/Database.php:102
+msgid "Manual"
+msgstr ""
+
+#: src/Admin/Pages/Media.php:44 src/Admin/Menu.php:54
+msgid "Media"
+msgstr ""
+
+#: src/Admin/Pages/Media.php:27
+msgid "Media Optimization"
+msgstr ""
+
+#: src/Admin/Pages/Dashboard.php:142
+msgid "Metric"
+msgstr ""
+
+#: src/Admin/Pages/Assets.php:83
+msgid "Minify HTML output"
+msgstr ""
+
+#: src/Admin/Pages/Settings.php:75
+msgid "Minimum role to manage plugin"
+msgstr ""
+
+#: src/Admin/Pages/Tools.php:101
+msgid "Missing"
+msgstr ""
+
+#: src/Admin/Pages/Logs.php:43
+msgid "Monitoring"
+msgstr ""
+
+#: src/Admin/Pages/Database.php:104
+msgid "Monthly"
+msgstr ""
+
+#: src/Admin/Pages/Database.php:76
+msgid "Never"
+msgstr ""
+
+#: src/Admin/Pages/Logs.php:68
+msgid "No backup available to revert."
+msgstr ""
+
+#: src/Admin/Pages/Logs.php:118
+msgid "Notice"
+msgstr ""
+
+#: src/Admin/Pages/Media.php:123
+msgid "Offset"
+msgstr ""
+
+#: src/Services/DB/Cleaner.php:72
+msgid "Once Monthly (FP Performance Suite)"
+msgstr ""
+
+#: src/Services/DB/Cleaner.php:68
+msgid "Once Weekly (FP Performance Suite)"
+msgstr ""
+
+#: src/Admin/Pages/Cache.php:45 src/Admin/Pages/Database.php:48 src/Admin/Pages/Presets.php:43 src/Admin/Pages/Media.php:44 src/Admin/Pages/Assets.php:47
+msgid "Optimization"
+msgstr ""
+
+#: src/Admin/Pages/Database.php:87
+msgid "Optimize tables"
+msgstr ""
+
+#: src/Admin/Pages/Database.php:84
+msgid "Orphan post meta"
+msgstr ""
+
+#: src/Admin/Pages/Database.php:85
+msgid "Orphan term meta"
+msgstr ""
+
+#: src/Admin/Pages/Database.php:86
+msgid "Orphan user meta"
+msgstr ""
+
+#: src/Admin/Pages/Cache.php:90
+msgid "Page Cache"
+msgstr ""
+
+#: src/Services/Score/Scorer.php:57
+msgid "Page cache"
+msgstr ""
+
+#: src/Admin/Pages/Cache.php:76
+msgid "Page cache cleared."
+msgstr ""
+
+#: src/Admin/Pages/Tools.php:100
+msgid "Page cache enabled"
+msgstr ""
+
+#: src/Admin/Pages/Cache.php:61
+msgid "Page cache settings saved."
+msgstr ""
+
+#: src/Services/Score/Scorer.php:122
+msgid "Page caching enabled"
+msgstr ""
+
+#: src/Admin/Pages/Tools.php:100 src/Admin/Pages/Tools.php:101
+msgid "Pass"
+msgstr ""
+
+#: src/Admin/Pages/Tools.php:121
+msgid "Paste JSON export here"
+msgstr ""
+
+#: src/Admin/Pages/Settings.php:90
+msgid "Paste above-the-fold CSS or snippet reference."
+msgstr ""
+
+#: src/Admin/Pages/Database.php:79
+msgid "Post revisions"
+msgstr ""
+
+#: src/Admin/Pages/Assets.php:132
+msgid "Preload resources (full URLs)"
+msgstr ""
+
+#: src/Admin/Pages/Presets.php:26
+msgid "Preset Bundles"
+msgstr ""
+
+#: src/Services/Presets/Manager.php:80
+msgid "Preset not found"
+msgstr ""
+
+#: src/Admin/Pages/Dashboard.php:94
+msgid "Preset:"
+msgstr ""
+
+#: src/Admin/Pages/Presets.php:43 src/Admin/Menu.php:56
+msgid "Presets"
+msgstr ""
+
+#: src/Admin/Pages/Media.php:90
+msgid "Quality (0-100)"
+msgstr ""
+
+#: src/Admin/Pages/Dashboard.php:103
+msgid "Quick Actions"
+msgstr ""
+
+#: src/Admin/Pages/Logs.php:26
+msgid "Realtime Log Center"
+msgstr ""
+
+#: src/Admin/Pages/Logs.php:112
+msgid "Realtime Viewer"
+msgstr ""
+
+#: src/Admin/Pages/Cache.php:98
+msgid "Recommended for shared hosting with limited CPU."
+msgstr ""
+
+#: src/Admin/Pages/Assets.php:105 src/Admin/Pages/Assets.php:112 src/Admin/Pages/Logs.php:87
+msgid "Red"
+msgstr ""
+
+#: src/Admin/Pages/Assets.php:118
+msgid "Remove emojis script"
+msgstr ""
+
+#: src/Admin/Pages/Logs.php:105
+msgid "Revert to Backup"
+msgstr ""
+
+#: src/Services/Score/Scorer.php:257
+msgid "Review debug log for warnings in the last 24 hours."
+msgstr ""
+
+#: src/Admin/Pages/Presets.php:75
+msgid "Rollback"
+msgstr ""
+
+#: src/Admin/Pages/Media.php:127
+msgid "Run Bulk Conversion"
+msgstr ""
+
+#: src/Admin/Pages/Dashboard.php:108
+msgid "Run Tests"
+msgstr ""
+
+#: src/Services/Score/Scorer.php:194
+msgid "Run bulk WebP conversion to improve coverage."
+msgstr ""
+
+#: src/Services/Score/Scorer.php:208
+msgid "Run database optimization to reclaim space."
+msgstr ""
+
+#: src/Admin/Pages/Dashboard.php:104
+msgid "Run safe optimizations and diagnostics."
+msgstr ""
+
+#: src/Admin/Pages/Presets.php:64
+msgid "Safe defaults crafted for shared hosting providers."
+msgstr ""
+
+#: src/Admin/Pages/Settings.php:83
+msgid "Safety mode"
+msgstr ""
+
+#: src/Admin/Pages/Assets.php:136
+msgid "Save Asset Settings"
+msgstr ""
+
+#: src/Admin/Pages/Logs.php:99
+msgid "Save Debug Settings"
+msgstr ""
+
+#: src/Admin/Pages/Cache.php:138
+msgid "Save Headers"
+msgstr ""
+
+#: src/Admin/Pages/Media.php:108
+msgid "Save Media Settings"
+msgstr ""
+
+#: src/Admin/Pages/Cache.php:107
+msgid "Save Page Cache"
+msgstr ""
+
+#: src/Admin/Pages/Database.php:112
+msgid "Save Scheduler"
+msgstr ""
+
+#: src/Admin/Pages/Settings.php:92
+msgid "Save Settings"
+msgstr ""
+
+#: src/Services/Score/Scorer.php:206
+msgid "Schedule routine database cleanup to reduce overhead."
+msgstr ""
+
+#: src/Admin/Pages/Database.php:95
+msgid "Scheduler"
+msgstr ""
+
+#: src/Admin/Pages/Dashboard.php:74
+msgid "Score is calculated from caching, assets, images, database, and logging health."
+msgstr ""
+
+#: src/Admin/Pages/Logs.php:123
+msgid "Search"
+msgstr ""
+
+#: src/Admin/Pages/Tools.php:68
+msgid "Security check failed. Please try again."
+msgstr ""
+
+#: src/Admin/Pages/Database.php:123
+msgid "Select components to clean. Red actions require PROCEDI confirmation."
+msgstr ""
+
+#: src/Admin/Pages/Cache.php:91
+msgid "Serve cached HTML for anonymous visitors using filesystem storage."
+msgstr ""
+
+#: src/Admin/Pages/Settings.php:29 src/Admin/Menu.php:59
+msgid "Settings"
+msgstr ""
+
+#: src/Admin/Pages/Tools.php:85
+msgid "Settings imported successfully."
+msgstr ""
+
+#: src/Admin/Pages/Settings.php:63
+msgid "Settings saved."
+msgstr ""
+
+#: src/Admin/Pages/Database.php:82
+msgid "Spam/trashed comments"
+msgstr ""
+
+#: src/Admin/Pages/Dashboard.php:155
+msgid "Suggestions"
+msgstr ""
+
+#: src/Admin/Pages/Database.php:148
+msgid "Task"
+msgstr ""
+
+#: src/Admin/Pages/Dashboard.php:72
+msgid "Technical SEO Performance Score"
+msgstr ""
+
+#: src/Services/Score/Scorer.php:221
+msgid "Throttle heartbeat on shared hosting to 60 seconds."
+msgstr ""
+
+#: src/Admin/Pages/Tools.php:52 src/Admin/Menu.php:58
+msgid "Tools"
+msgstr ""
+
+#: src/Admin/Pages/Tools.php:35
+msgid "Tools & Export"
+msgstr ""
+
+#: src/Admin/Pages/Dashboard.php:143
+msgid "Total Score"
+msgstr ""
+
+#: src/Admin/Pages/Database.php:81
+msgid "Trashed posts"
+msgstr ""
+
+#: src/Admin/Assets.php:35
+msgid "Type PROCEDI to confirm high-risk actions"
+msgstr ""
+
+#: src/Admin/Assets.php:39
+msgid "Unable to apply preset."
+msgstr ""
+
+#: src/Admin/Assets.php:38
+msgid "Unable to load log data."
+msgstr ""
+
+#: src/Http/Routes.php:106
+msgid "Unable to toggle debug mode."
+msgstr ""
+
+#: src/Admin/Pages/Logs.php:60
+msgid "Unable to update wp-config.php. Check file permissions."
+msgstr ""
+
+#: src/Admin/Pages/Media.php:102
+msgid "Use lossy compression"
+msgstr ""
+
+#: src/Admin/Pages/Dashboard.php:142
+msgid "Value"
+msgstr ""
+
+#: src/Admin/Pages/Dashboard.php:97
+msgid "View Logs"
+msgstr ""
+
+#: src/Admin/Pages/Logs.php:119
+msgid "Warning"
+msgstr ""
+
+#: src/Admin/Pages/Media.php:78
+msgid "WebP Conversion"
+msgstr ""
+
+#: src/Services/Score/Scorer.php:137
+msgid "WebP conversion enabled"
+msgstr ""
+
+#: src/Services/Score/Scorer.php:71 src/Admin/Pages/Tools.php:102
+msgid "WebP coverage"
+msgstr ""
+
+#: src/Admin/Pages/Media.php:61
+msgid "WebP settings saved."
+msgstr ""
+
+#: src/Admin/Pages/Database.php:103
+msgid "Weekly"
+msgstr ""
+
+#: src/Admin/Pages/AbstractPage.php:29
+msgid "You do not have permission to access this page."
+msgstr ""
+
+#: src/Admin/Pages/Dashboard.php:128
+msgid "You do not have permission to export this report."
+msgstr ""
+
+#: src/Admin/Pages/Logs.php:65
+msgid "wp-config.php reverted from backup."
+msgstr ""
+

--- a/fp-performance-suite/phpcs.xml.dist
+++ b/fp-performance-suite/phpcs.xml.dist
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<ruleset name="FP Performance Suite">
+    <description>WordPress VIP compliant coding standards</description>
+    <rule ref="WordPressVIPMinimum" />
+    <file>src</file>
+</ruleset>

--- a/fp-performance-suite/phpstan.neon.dist
+++ b/fp-performance-suite/phpstan.neon.dist
@@ -1,0 +1,8 @@
+includes:
+    - vendor/phpstan/phpstan-wordpress/extension.neon
+
+parameters:
+    level: 6
+    paths:
+        - src
+    tmpDir: build/phpstan

--- a/fp-performance-suite/phpunit.xml.dist
+++ b/fp-performance-suite/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php" colors="true">
+    <testsuites>
+        <testsuite name="FP Performance Suite">
+            <directory suffix="Test.php">tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/fp-performance-suite/src/Admin/Assets.php
+++ b/fp-performance-suite/src/Admin/Assets.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace FP\PerfSuite\Admin;
+
+class Assets
+{
+    public function boot(): void
+    {
+        add_action('admin_enqueue_scripts', [$this, 'enqueue']);
+    }
+
+    public function enqueue(string $hook): void
+    {
+        if (strpos($hook, 'fp-performance-suite') === false) {
+            return;
+        }
+
+        wp_enqueue_style(
+            'fp-performance-suite-admin',
+            plugins_url('assets/admin.css', FP_PERF_SUITE_FILE),
+            [],
+            FP_PERF_SUITE_VERSION
+        );
+
+        wp_enqueue_script(
+            'fp-performance-suite-admin',
+            plugins_url('assets/admin.js', FP_PERF_SUITE_FILE),
+            ['wp-i18n'],
+            FP_PERF_SUITE_VERSION,
+            true
+        );
+
+        wp_localize_script('fp-performance-suite-admin', 'fpPerfSuite', [
+            'restUrl' => esc_url_raw(get_rest_url(null, 'fp-ps/v1/')),
+            'confirmLabel' => __('Type PROCEDI to confirm high-risk actions', 'fp-performance-suite'),
+            'cancelledLabel' => __('Action cancelled', 'fp-performance-suite'),
+            'messages' => [
+                'logsError' => __('Unable to load log data.', 'fp-performance-suite'),
+                'presetError' => __('Unable to apply preset.', 'fp-performance-suite'),
+            ],
+        ]);
+    }
+}

--- a/fp-performance-suite/src/Admin/Menu.php
+++ b/fp-performance-suite/src/Admin/Menu.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace FP\PerfSuite\Admin;
+
+use FP\PerfSuite\Admin\Pages\Assets;
+use FP\PerfSuite\Admin\Pages\Cache;
+use FP\PerfSuite\Admin\Pages\Dashboard;
+use FP\PerfSuite\Admin\Pages\Database;
+use FP\PerfSuite\Admin\Pages\Logs;
+use FP\PerfSuite\Admin\Pages\Media;
+use FP\PerfSuite\Admin\Pages\Presets;
+use FP\PerfSuite\Admin\Pages\Settings;
+use FP\PerfSuite\Admin\Pages\Tools;
+use FP\PerfSuite\ServiceContainer;
+use function add_action;
+use function add_menu_page;
+use function add_submenu_page;
+use function get_option;
+use function __;
+
+class Menu
+{
+    private ServiceContainer $container;
+
+    public function __construct(ServiceContainer $container)
+    {
+        $this->container = $container;
+    }
+
+    public function boot(): void
+    {
+        add_action('admin_menu', [$this, 'register']);
+    }
+
+    public function register(): void
+    {
+        $pages = $this->pages();
+        $settings = get_option('fp_ps_settings', ['allowed_role' => 'administrator']);
+        $capability = $settings['allowed_role'] === 'editor' ? 'edit_pages' : 'manage_options';
+
+        add_menu_page(
+            __('FP Performance Suite', 'fp-performance-suite'),
+            __('FP Performance', 'fp-performance-suite'),
+            $capability,
+            'fp-performance-suite',
+            [$pages['dashboard'], 'render'],
+            'dashicons-performance',
+            59
+        );
+
+        add_submenu_page('fp-performance-suite', __('Dashboard', 'fp-performance-suite'), __('Dashboard', 'fp-performance-suite'), $capability, 'fp-performance-suite', [$pages['dashboard'], 'render']);
+        add_submenu_page('fp-performance-suite', __('Cache', 'fp-performance-suite'), __('Cache', 'fp-performance-suite'), $capability, 'fp-performance-suite-cache', [$pages['cache'], 'render']);
+        add_submenu_page('fp-performance-suite', __('Assets', 'fp-performance-suite'), __('Assets', 'fp-performance-suite'), $capability, 'fp-performance-suite-assets', [$pages['assets'], 'render']);
+        add_submenu_page('fp-performance-suite', __('Media', 'fp-performance-suite'), __('Media', 'fp-performance-suite'), $capability, 'fp-performance-suite-media', [$pages['media'], 'render']);
+        add_submenu_page('fp-performance-suite', __('Database', 'fp-performance-suite'), __('Database', 'fp-performance-suite'), $capability, 'fp-performance-suite-database', [$pages['database'], 'render']);
+        add_submenu_page('fp-performance-suite', __('Presets', 'fp-performance-suite'), __('Presets', 'fp-performance-suite'), $capability, 'fp-performance-suite-presets', [$pages['presets'], 'render']);
+        add_submenu_page('fp-performance-suite', __('Logs', 'fp-performance-suite'), __('Logs', 'fp-performance-suite'), $capability, 'fp-performance-suite-logs', [$pages['logs'], 'render']);
+        add_submenu_page('fp-performance-suite', __('Tools', 'fp-performance-suite'), __('Tools', 'fp-performance-suite'), $capability, 'fp-performance-suite-tools', [$pages['tools'], 'render']);
+        add_submenu_page('fp-performance-suite', __('Settings', 'fp-performance-suite'), __('Settings', 'fp-performance-suite'), 'manage_options', 'fp-performance-suite-settings', [$pages['settings'], 'render']);
+    }
+
+    /**
+     * @return array<string, object>
+     */
+    private function pages(): array
+    {
+        return [
+            'dashboard' => new Dashboard($this->container),
+            'cache' => new Cache($this->container),
+            'assets' => new Assets($this->container),
+            'media' => new Media($this->container),
+            'database' => new Database($this->container),
+            'presets' => new Presets($this->container),
+            'logs' => new Logs($this->container),
+            'tools' => new Tools($this->container),
+            'settings' => new Settings($this->container),
+        ];
+    }
+}

--- a/fp-performance-suite/src/Admin/Pages/AbstractPage.php
+++ b/fp-performance-suite/src/Admin/Pages/AbstractPage.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace FP\PerfSuite\Admin\Pages;
+
+use FP\PerfSuite\ServiceContainer;
+
+abstract class AbstractPage
+{
+    protected ServiceContainer $container;
+
+    public function __construct(ServiceContainer $container)
+    {
+        $this->container = $container;
+    }
+
+    abstract public function slug(): string;
+
+    abstract public function title(): string;
+
+    abstract public function capability(): string;
+
+    abstract public function view(): string;
+
+    abstract protected function content(): string;
+
+    public function render(): void
+    {
+        if (!current_user_can($this->capability())) {
+            wp_die(esc_html__('You do not have permission to access this page.', 'fp-performance-suite'));
+        }
+
+        $view = $this->view();
+        $data = $this->data();
+        $data['content'] = $this->content();
+        if (is_readable($view)) {
+            $pageData = $data;
+            include $view;
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function data(): array
+    {
+        return [];
+    }
+}

--- a/fp-performance-suite/src/Admin/Pages/Assets.php
+++ b/fp-performance-suite/src/Admin/Pages/Assets.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace FP\PerfSuite\Admin\Pages;
+
+use FP\PerfSuite\Services\Assets\Optimizer;
+use function __;
+use function array_filter;
+use function array_map;
+use function checked;
+use function esc_attr;
+use function esc_html;
+use function esc_html_e;
+use function esc_textarea;
+use function explode;
+use function implode;
+use function trim;
+use function wp_nonce_field;
+use function wp_unslash;
+use function wp_verify_nonce;
+
+class Assets extends AbstractPage
+{
+    public function slug(): string
+    {
+        return 'fp-performance-suite-assets';
+    }
+
+    public function title(): string
+    {
+        return __('Assets Optimization', 'fp-performance-suite');
+    }
+
+    public function capability(): string
+    {
+        return 'manage_options';
+    }
+
+    public function view(): string
+    {
+        return FP_PERF_SUITE_DIR . '/views/admin-page.php';
+    }
+
+    protected function data(): array
+    {
+        return [
+            'title' => $this->title(),
+            'breadcrumbs' => [__('Optimization', 'fp-performance-suite'), __('Assets', 'fp-performance-suite')],
+        ];
+    }
+
+    protected function content(): string
+    {
+        $optimizer = $this->container->get(Optimizer::class);
+        $message = '';
+        if ('POST' === $_SERVER['REQUEST_METHOD'] && isset($_POST['fp_ps_assets_nonce']) && wp_verify_nonce(wp_unslash($_POST['fp_ps_assets_nonce']), 'fp-ps-assets')) {
+            $dnsPrefetch = array_filter(array_map('trim', explode("\n", wp_unslash($_POST['dns_prefetch'] ?? ''))));
+            $preload = array_filter(array_map('trim', explode("\n", wp_unslash($_POST['preload'] ?? ''))));
+            $optimizer->update([
+                'minify_html' => !empty($_POST['minify_html']),
+                'defer_js' => !empty($_POST['defer_js']),
+                'async_js' => !empty($_POST['async_js']),
+                'remove_emojis' => !empty($_POST['remove_emojis']),
+                'dns_prefetch' => $dnsPrefetch,
+                'preload' => $preload,
+                'heartbeat_admin' => (int) ($_POST['heartbeat_admin'] ?? 60),
+                'combine_css' => !empty($_POST['combine_css']),
+                'combine_js' => !empty($_POST['combine_js']),
+            ]);
+            $message = __('Asset settings saved.', 'fp-performance-suite');
+        }
+        $settings = $optimizer->settings();
+        ob_start();
+        ?>
+        <?php if ($message) : ?>
+            <div class="notice notice-success"><p><?php echo esc_html($message); ?></p></div>
+        <?php endif; ?>
+        <section class="fp-ps-card">
+            <h2><?php esc_html_e('Delivery', 'fp-performance-suite'); ?></h2>
+            <form method="post">
+                <?php wp_nonce_field('fp-ps-assets', 'fp_ps_assets_nonce'); ?>
+                <label class="fp-ps-toggle">
+                    <span class="info">
+                        <strong><?php esc_html_e('Minify HTML output', 'fp-performance-suite'); ?></strong>
+                        <span class="fp-ps-badge amber"><?php esc_html_e('Amber', 'fp-performance-suite'); ?></span>
+                    </span>
+                    <input type="checkbox" name="minify_html" value="1" <?php checked($settings['minify_html']); ?> />
+                </label>
+                <label class="fp-ps-toggle">
+                    <span class="info">
+                        <strong><?php esc_html_e('Defer JavaScript', 'fp-performance-suite'); ?></strong>
+                        <span class="fp-ps-badge amber"><?php esc_html_e('Amber', 'fp-performance-suite'); ?></span>
+                    </span>
+                    <input type="checkbox" name="defer_js" value="1" <?php checked($settings['defer_js']); ?> data-risk="amber" />
+                </label>
+                <label class="fp-ps-toggle">
+                    <span class="info">
+                        <strong><?php esc_html_e('Async JavaScript', 'fp-performance-suite'); ?></strong>
+                        <span class="fp-ps-badge amber"><?php esc_html_e('Amber', 'fp-performance-suite'); ?></span>
+                    </span>
+                    <input type="checkbox" name="async_js" value="1" <?php checked($settings['async_js']); ?> data-risk="amber" />
+                </label>
+                <label class="fp-ps-toggle">
+                    <span class="info">
+                        <strong><?php esc_html_e('Combine CSS files', 'fp-performance-suite'); ?></strong>
+                        <span class="fp-ps-badge red"><?php esc_html_e('Red', 'fp-performance-suite'); ?></span>
+                    </span>
+                    <input type="checkbox" name="combine_css" value="1" <?php checked($settings['combine_css']); ?> data-risk="red" />
+                </label>
+                <label class="fp-ps-toggle">
+                    <span class="info">
+                        <strong><?php esc_html_e('Combine JS files', 'fp-performance-suite'); ?></strong>
+                        <span class="fp-ps-badge red"><?php esc_html_e('Red', 'fp-performance-suite'); ?></span>
+                    </span>
+                    <input type="checkbox" name="combine_js" value="1" <?php checked($settings['combine_js']); ?> data-risk="red" />
+                </label>
+                <label class="fp-ps-toggle">
+                    <span class="info">
+                        <strong><?php esc_html_e('Remove emojis script', 'fp-performance-suite'); ?></strong>
+                        <span class="fp-ps-badge green"><?php esc_html_e('Green', 'fp-performance-suite'); ?></span>
+                    </span>
+                    <input type="checkbox" name="remove_emojis" value="1" <?php checked($settings['remove_emojis']); ?> data-risk="green" />
+                </label>
+                <p>
+                    <label for="heartbeat_admin"><?php esc_html_e('Heartbeat interval (seconds)', 'fp-performance-suite'); ?></label>
+                    <input type="number" name="heartbeat_admin" id="heartbeat_admin" value="<?php echo esc_attr((string) $settings['heartbeat_admin']); ?>" min="15" step="5" />
+                </p>
+                <p>
+                    <label for="dns_prefetch"><?php esc_html_e('DNS Prefetch domains (one per line)', 'fp-performance-suite'); ?></label>
+                    <textarea name="dns_prefetch" id="dns_prefetch" rows="4" class="large-text code"><?php echo esc_textarea(implode("\n", $settings['dns_prefetch'])); ?></textarea>
+                </p>
+                <p>
+                    <label for="preload"><?php esc_html_e('Preload resources (full URLs)', 'fp-performance-suite'); ?></label>
+                    <textarea name="preload" id="preload" rows="4" class="large-text code"><?php echo esc_textarea(implode("\n", $settings['preload'])); ?></textarea>
+                </p>
+                <p>
+                    <button type="submit" class="button button-primary"><?php esc_html_e('Save Asset Settings', 'fp-performance-suite'); ?></button>
+                </p>
+            </form>
+        </section>
+        <?php
+        return (string) ob_get_clean();
+    }
+}

--- a/fp-performance-suite/src/Admin/Pages/Cache.php
+++ b/fp-performance-suite/src/Admin/Pages/Cache.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace FP\PerfSuite\Admin\Pages;
+
+use FP\PerfSuite\ServiceContainer;
+use FP\PerfSuite\Services\Cache\Headers;
+use FP\PerfSuite\Services\Cache\PageCache;
+use function __;
+use function checked;
+use function esc_attr;
+use function esc_html_e;
+use function esc_textarea;
+use function printf;
+use function sanitize_text_field;
+use function sanitize_textarea_field;
+use function wp_nonce_field;
+use function wp_unslash;
+
+class Cache extends AbstractPage
+{
+    public function slug(): string
+    {
+        return 'fp-performance-suite-cache';
+    }
+
+    public function title(): string
+    {
+        return __('Cache Optimization', 'fp-performance-suite');
+    }
+
+    public function capability(): string
+    {
+        return 'manage_options';
+    }
+
+    public function view(): string
+    {
+        return FP_PERF_SUITE_DIR . '/views/admin-page.php';
+    }
+
+    protected function data(): array
+    {
+        return [
+            'title' => $this->title(),
+            'breadcrumbs' => [__('Optimization', 'fp-performance-suite'), __('Cache', 'fp-performance-suite')],
+        ];
+    }
+
+    protected function content(): string
+    {
+        $pageCache = $this->container->get(PageCache::class);
+        $headers = $this->container->get(Headers::class);
+        $message = '';
+
+        if ('POST' === $_SERVER['REQUEST_METHOD'] && isset($_POST['fp_ps_cache_nonce']) && wp_verify_nonce(wp_unslash($_POST['fp_ps_cache_nonce']), 'fp-ps-cache')) {
+            if (isset($_POST['fp_ps_page_cache'])) {
+                $pageCache->update([
+                    'enabled' => !empty($_POST['page_cache_enabled']),
+                    'ttl' => (int) ($_POST['page_cache_ttl'] ?? 3600),
+                ]);
+                $message = __('Page cache settings saved.', 'fp-performance-suite');
+            }
+            if (isset($_POST['fp_ps_browser_cache'])) {
+                $headers->update([
+                    'enabled' => !empty($_POST['browser_cache_enabled']),
+                    'headers' => [
+                        'Cache-Control' => sanitize_text_field($_POST['cache_control'] ?? 'public, max-age=31536000'),
+                        'Expires' => sanitize_text_field($_POST['expires_header'] ?? ''),
+                    ],
+                    'htaccess' => sanitize_textarea_field($_POST['htaccess_rules'] ?? ''),
+                ]);
+                $message = __('Browser cache settings saved.', 'fp-performance-suite');
+            }
+            if (isset($_POST['fp_ps_clear_cache'])) {
+                $pageCache->clear();
+                $message = __('Page cache cleared.', 'fp-performance-suite');
+            }
+        }
+
+        $pageSettings = $pageCache->settings();
+        $headerSettings = $headers->settings();
+        $status = $pageCache->status();
+
+        ob_start();
+        ?>
+        <?php if ($message) : ?>
+            <div class="notice notice-success"><p><?php echo esc_html($message); ?></p></div>
+        <?php endif; ?>
+        <section class="fp-ps-card">
+            <h2><?php esc_html_e('Page Cache', 'fp-performance-suite'); ?></h2>
+            <p><?php esc_html_e('Serve cached HTML for anonymous visitors using filesystem storage.', 'fp-performance-suite'); ?></p>
+            <form method="post">
+                <?php wp_nonce_field('fp-ps-cache', 'fp_ps_cache_nonce'); ?>
+                <input type="hidden" name="fp_ps_page_cache" value="1" />
+                <label class="fp-ps-toggle">
+                    <span class="info">
+                        <strong><?php esc_html_e('Enable page cache', 'fp-performance-suite'); ?></strong>
+                        <span class="description"><?php esc_html_e('Recommended for shared hosting with limited CPU.', 'fp-performance-suite'); ?></span>
+                    </span>
+                    <input type="checkbox" name="page_cache_enabled" value="1" <?php checked($pageSettings['enabled']); ?> data-risk="amber" />
+                </label>
+                <p>
+                    <label for="page_cache_ttl"><?php esc_html_e('Cache lifetime (seconds)', 'fp-performance-suite'); ?></label>
+                    <input type="number" name="page_cache_ttl" id="page_cache_ttl" value="<?php echo esc_attr((string) $pageSettings['ttl']); ?>" min="60" step="60" />
+                </p>
+                <p>
+                    <button type="submit" class="button button-primary"><?php esc_html_e('Save Page Cache', 'fp-performance-suite'); ?></button>
+                    <button type="submit" name="fp_ps_clear_cache" value="1" class="button"><?php esc_html_e('Clear Cache', 'fp-performance-suite'); ?></button>
+                </p>
+                <p class="description"><?php printf(esc_html__('Current cached files: %d', 'fp-performance-suite'), (int) $status['files']); ?></p>
+            </form>
+        </section>
+        <section class="fp-ps-card">
+            <h2><?php esc_html_e('Browser Cache Headers', 'fp-performance-suite'); ?></h2>
+            <form method="post">
+                <?php wp_nonce_field('fp-ps-cache', 'fp_ps_cache_nonce'); ?>
+                <input type="hidden" name="fp_ps_browser_cache" value="1" />
+                <label class="fp-ps-toggle">
+                    <span class="info">
+                        <strong><?php esc_html_e('Enable headers', 'fp-performance-suite'); ?></strong>
+                        <span class="description"><?php esc_html_e('Adds Cache-Control/Expires headers for static files.', 'fp-performance-suite'); ?></span>
+                    </span>
+                    <input type="checkbox" name="browser_cache_enabled" value="1" <?php checked($headerSettings['enabled']); ?> data-risk="green" />
+                </label>
+                <p>
+                    <label for="cache_control"><?php esc_html_e('Cache-Control', 'fp-performance-suite'); ?></label>
+                    <input type="text" name="cache_control" id="cache_control" value="<?php echo esc_attr($headerSettings['headers']['Cache-Control']); ?>" class="regular-text" />
+                </p>
+                <p>
+                    <label for="expires_header"><?php esc_html_e('Expires header', 'fp-performance-suite'); ?></label>
+                    <input type="text" name="expires_header" id="expires_header" value="<?php echo esc_attr($headerSettings['headers']['Expires'] ?? ''); ?>" class="regular-text" />
+                </p>
+                <p>
+                    <label for="htaccess_rules"><?php esc_html_e('.htaccess rules', 'fp-performance-suite'); ?></label>
+                    <textarea name="htaccess_rules" id="htaccess_rules" rows="6" class="large-text code"><?php echo esc_textarea($headerSettings['htaccess']); ?></textarea>
+                </p>
+                <p>
+                    <button type="submit" class="button button-primary"><?php esc_html_e('Save Headers', 'fp-performance-suite'); ?></button>
+                </p>
+            </form>
+        </section>
+        <?php
+        return (string) ob_get_clean();
+    }
+}

--- a/fp-performance-suite/src/Admin/Pages/Dashboard.php
+++ b/fp-performance-suite/src/Admin/Pages/Dashboard.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace FP\PerfSuite\Admin\Pages;
+
+use FP\PerfSuite\ServiceContainer;
+use FP\PerfSuite\Services\Presets\Manager as PresetManager;
+use FP\PerfSuite\Services\Score\Scorer;
+use function __;
+use function add_action;
+use function admin_url;
+use function check_admin_referer;
+use function current_user_can;
+use function esc_html;
+use function esc_html__;
+use function esc_html_e;
+use function esc_url;
+use function fputcsv;
+use function header;
+use function nocache_headers;
+use function wp_die;
+use function wp_nonce_url;
+
+class Dashboard extends AbstractPage
+{
+    public function __construct(ServiceContainer $container)
+    {
+        parent::__construct($container);
+        add_action('admin_post_fp_ps_export_csv', [$this, 'exportCsv']);
+    }
+
+    public function slug(): string
+    {
+        return 'fp-performance-suite';
+    }
+
+    public function title(): string
+    {
+        return __('FP Performance Suite', 'fp-performance-suite');
+    }
+
+    public function capability(): string
+    {
+        return 'manage_options';
+    }
+
+    public function view(): string
+    {
+        return FP_PERF_SUITE_DIR . '/views/admin-page.php';
+    }
+
+    protected function data(): array
+    {
+        return [
+            'title' => $this->title(),
+            'breadcrumbs' => [__('Dashboard', 'fp-performance-suite')],
+        ];
+    }
+
+    protected function content(): string
+    {
+        $scorer = $this->container->get(Scorer::class);
+        $score = $scorer->calculate();
+        $presetManager = $this->container->get(PresetManager::class);
+        $active = $presetManager->getActivePreset();
+        $activeLabel = $active ? $presetManager->labelFor($active) : __('Custom', 'fp-performance-suite');
+        $exportUrl = wp_nonce_url(admin_url('admin-post.php?action=fp_ps_export_csv'), 'fp-ps-export');
+
+        ob_start();
+        ?>
+        <section class="fp-ps-grid two">
+            <div class="fp-ps-card">
+                <h2><?php esc_html_e('Technical SEO Performance Score', 'fp-performance-suite'); ?></h2>
+                <div class="fp-ps-score" aria-live="polite"><?php echo esc_html((string) $score['total']); ?></div>
+                <p><?php esc_html_e('Score is calculated from caching, assets, images, database, and logging health.', 'fp-performance-suite'); ?></p>
+                <table class="fp-ps-table" aria-describedby="fp-ps-score-desc">
+                    <tbody>
+                    <?php foreach ($score['breakdown'] as $label => $value) : ?>
+                        <tr>
+                            <th scope="row"><?php echo esc_html($label); ?></th>
+                            <td><?php echo esc_html((string) $value); ?></td>
+                        </tr>
+                    <?php endforeach; ?>
+                    </tbody>
+                </table>
+                <p id="fp-ps-score-desc" class="description"><?php esc_html_e('Higher score indicates better technical readiness for shared hosting.', 'fp-performance-suite'); ?></p>
+            </div>
+            <div class="fp-ps-card">
+                <h2><?php esc_html_e('Active Optimizations', 'fp-performance-suite'); ?></h2>
+                <ul>
+                    <?php foreach ($scorer->activeOptimizations() as $opt) : ?>
+                        <li><?php echo esc_html($opt); ?></li>
+                    <?php endforeach; ?>
+                </ul>
+                <p><strong><?php esc_html_e('Preset:', 'fp-performance-suite'); ?></strong> <?php echo esc_html($activeLabel); ?></p>
+                <div class="fp-ps-actions">
+                    <a class="button button-primary" href="<?php echo esc_url(admin_url('admin.php?page=fp-performance-suite-cache')); ?>"><?php esc_html_e('Configure Cache', 'fp-performance-suite'); ?></a>
+                    <a class="button" href="<?php echo esc_url(admin_url('admin.php?page=fp-performance-suite-logs')); ?>"><?php esc_html_e('View Logs', 'fp-performance-suite'); ?></a>
+                </div>
+            </div>
+        </section>
+        <section class="fp-ps-grid two">
+            <div class="fp-ps-card">
+                <h2><?php esc_html_e('Quick Actions', 'fp-performance-suite'); ?></h2>
+                <p><?php esc_html_e('Run safe optimizations and diagnostics.', 'fp-performance-suite'); ?></p>
+                <div class="fp-ps-actions">
+                    <a class="button" href="<?php echo esc_url(admin_url('admin.php?page=fp-performance-suite-database')); ?>"><?php esc_html_e('Database Cleanup', 'fp-performance-suite'); ?></a>
+                    <a class="button" href="<?php echo esc_url(admin_url('admin.php?page=fp-performance-suite-media')); ?>"><?php esc_html_e('Bulk WebP Convert', 'fp-performance-suite'); ?></a>
+                    <a class="button" href="<?php echo esc_url(admin_url('admin.php?page=fp-performance-suite-tools')); ?>"><?php esc_html_e('Run Tests', 'fp-performance-suite'); ?></a>
+                    <a class="button" href="<?php echo esc_url($exportUrl); ?>"><?php esc_html_e('Export CSV Summary', 'fp-performance-suite'); ?></a>
+                </div>
+            </div>
+            <div class="fp-ps-card">
+                <h2><?php esc_html_e('Issues & Suggestions', 'fp-performance-suite'); ?></h2>
+                <ul>
+                    <?php foreach ($score['suggestions'] as $suggestion) : ?>
+                        <li><?php echo esc_html($suggestion); ?></li>
+                    <?php endforeach; ?>
+                </ul>
+            </div>
+        </section>
+        <?php
+        return (string) ob_get_clean();
+    }
+
+    public function exportCsv(): void
+    {
+        if (!current_user_can($this->capability())) {
+            wp_die(esc_html__('You do not have permission to export this report.', 'fp-performance-suite'));
+        }
+
+        check_admin_referer('fp-ps-export');
+
+        $scorer = $this->container->get(Scorer::class);
+        $score = $scorer->calculate();
+        $active = $scorer->activeOptimizations();
+
+        nocache_headers();
+        header('Content-Type: text/csv; charset=utf-8');
+        header('Content-Disposition: attachment; filename="fp-performance-suite-score-' . gmdate('Ymd-Hi') . '.csv"');
+
+        $output = fopen('php://output', 'w');
+        fputcsv($output, [__('Metric', 'fp-performance-suite'), __('Value', 'fp-performance-suite')]);
+        fputcsv($output, [__('Total Score', 'fp-performance-suite'), $score['total']]);
+        foreach ($score['breakdown'] as $label => $value) {
+            fputcsv($output, [$label, $value]);
+        }
+
+        fputcsv($output, []);
+        fputcsv($output, [__('Active Optimizations', 'fp-performance-suite')]);
+        foreach ($active as $item) {
+            fputcsv($output, [$item]);
+        }
+
+        fputcsv($output, []);
+        fputcsv($output, [__('Suggestions', 'fp-performance-suite')]);
+        foreach ($score['suggestions'] as $suggestion) {
+            fputcsv($output, [$suggestion]);
+        }
+
+        exit;
+    }
+}

--- a/fp-performance-suite/src/Admin/Pages/Database.php
+++ b/fp-performance-suite/src/Admin/Pages/Database.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace FP\PerfSuite\Admin\Pages;
+
+use FP\PerfSuite\Services\DB\Cleaner;
+use function __;
+use function array_map;
+use function date_i18n;
+use function get_option;
+use function checked;
+use function esc_attr;
+use function esc_html;
+use function esc_html_e;
+use function number_format_i18n;
+use function printf;
+use function sanitize_text_field;
+use function selected;
+use function wp_nonce_field;
+use function wp_unslash;
+use function wp_verify_nonce;
+
+class Database extends AbstractPage
+{
+    public function slug(): string
+    {
+        return 'fp-performance-suite-database';
+    }
+
+    public function title(): string
+    {
+        return __('Database Optimization', 'fp-performance-suite');
+    }
+
+    public function capability(): string
+    {
+        return 'manage_options';
+    }
+
+    public function view(): string
+    {
+        return FP_PERF_SUITE_DIR . '/views/admin-page.php';
+    }
+
+    protected function data(): array
+    {
+        return [
+            'title' => $this->title(),
+            'breadcrumbs' => [__('Optimization', 'fp-performance-suite'), __('Database', 'fp-performance-suite')],
+        ];
+    }
+
+    protected function content(): string
+    {
+        $cleaner = $this->container->get(Cleaner::class);
+        $message = '';
+        $results = [];
+        if ('POST' === $_SERVER['REQUEST_METHOD'] && isset($_POST['fp_ps_db_nonce']) && wp_verify_nonce(wp_unslash($_POST['fp_ps_db_nonce']), 'fp-ps-db')) {
+            if (isset($_POST['save_db_settings'])) {
+                $cleaner->update([
+                    'schedule' => sanitize_text_field($_POST['schedule'] ?? 'manual'),
+                    'batch' => (int) ($_POST['batch'] ?? 200),
+                ]);
+                $message = __('Database settings updated.', 'fp-performance-suite');
+            }
+            if (isset($_POST['run_cleanup'])) {
+                $scope = array_map('sanitize_text_field', (array) ($_POST['cleanup_scope'] ?? []));
+                $dry = !empty($_POST['dry_run']);
+                $results = $cleaner->cleanup($scope, $dry, (int) ($_POST['batch'] ?? 200));
+                $message = $dry ? __('Dry run completed.', 'fp-performance-suite') : __('Cleanup completed.', 'fp-performance-suite');
+            }
+        }
+        $settings = $cleaner->settings();
+        $status = $cleaner->status();
+        $overhead = $status['overhead_mb'];
+        $lastRun = empty($status['last_run'])
+            ? __('Never', 'fp-performance-suite')
+            : date_i18n(get_option('date_format') . ' ' . get_option('time_format'), (int) $status['last_run']);
+        $tasks = [
+            'revisions' => __('Post revisions', 'fp-performance-suite'),
+            'auto_drafts' => __('Auto drafts', 'fp-performance-suite'),
+            'trash_posts' => __('Trashed posts', 'fp-performance-suite'),
+            'spam_comments' => __('Spam/trashed comments', 'fp-performance-suite'),
+            'expired_transients' => __('Expired transients', 'fp-performance-suite'),
+            'orphan_postmeta' => __('Orphan post meta', 'fp-performance-suite'),
+            'orphan_termmeta' => __('Orphan term meta', 'fp-performance-suite'),
+            'orphan_usermeta' => __('Orphan user meta', 'fp-performance-suite'),
+            'optimize_tables' => __('Optimize tables', 'fp-performance-suite'),
+        ];
+        ob_start();
+        ?>
+        <?php if ($message) : ?>
+            <div class="notice notice-info"><p><?php echo esc_html($message); ?></p></div>
+        <?php endif; ?>
+        <section class="fp-ps-card">
+            <h2><?php esc_html_e('Scheduler', 'fp-performance-suite'); ?></h2>
+            <form method="post">
+                <?php wp_nonce_field('fp-ps-db', 'fp_ps_db_nonce'); ?>
+                <input type="hidden" name="save_db_settings" value="1" />
+                <p>
+                    <label for="schedule"><?php esc_html_e('Cleanup schedule', 'fp-performance-suite'); ?></label>
+                    <select name="schedule" id="schedule">
+                        <option value="manual" <?php selected($settings['schedule'], 'manual'); ?>><?php esc_html_e('Manual', 'fp-performance-suite'); ?></option>
+                        <option value="weekly" <?php selected($settings['schedule'], 'weekly'); ?>><?php esc_html_e('Weekly', 'fp-performance-suite'); ?></option>
+                        <option value="monthly" <?php selected($settings['schedule'], 'monthly'); ?>><?php esc_html_e('Monthly', 'fp-performance-suite'); ?></option>
+                    </select>
+                </p>
+                <p>
+                    <label for="batch"><?php esc_html_e('Batch size', 'fp-performance-suite'); ?></label>
+                    <input type="number" name="batch" id="batch" value="<?php echo esc_attr((string) $settings['batch']); ?>" min="50" max="500" />
+                </p>
+                <p>
+                    <button type="submit" class="button button-secondary"><?php esc_html_e('Save Scheduler', 'fp-performance-suite'); ?></button>
+                </p>
+            </form>
+            <p class="description"><?php printf(esc_html__('Current overhead: %s MB', 'fp-performance-suite'), number_format_i18n($overhead, 2)); ?></p>
+            <p class="description"><?php printf(esc_html__('Last automated cleanup: %s', 'fp-performance-suite'), esc_html($lastRun)); ?></p>
+        </section>
+        <section class="fp-ps-card">
+            <h2><?php esc_html_e('Cleanup Tools', 'fp-performance-suite'); ?></h2>
+            <form method="post">
+                <?php wp_nonce_field('fp-ps-db', 'fp_ps_db_nonce'); ?>
+                <input type="hidden" name="run_cleanup" value="1" />
+                <p><?php esc_html_e('Select components to clean. Red actions require PROCEDI confirmation.', 'fp-performance-suite'); ?></p>
+                <div class="fp-ps-grid two">
+                    <?php foreach ($tasks as $key => $label) : ?>
+                        <label class="fp-ps-toggle">
+                            <span class="info">
+                                <strong><?php echo esc_html($label); ?></strong>
+                            </span>
+                            <input type="checkbox" name="cleanup_scope[]" value="<?php echo esc_attr($key); ?>" data-risk="<?php echo $key === 'optimize_tables' ? 'red' : 'amber'; ?>" />
+                        </label>
+                    <?php endforeach; ?>
+                </div>
+                <label class="fp-ps-toggle">
+                    <span class="info">
+                        <strong><?php esc_html_e('Dry run', 'fp-performance-suite'); ?></strong>
+                    </span>
+                    <input type="checkbox" name="dry_run" value="1" checked data-risk="green" />
+                </label>
+                <p>
+                    <button type="submit" class="button button-primary" data-risk="red"><?php esc_html_e('Execute Cleanup', 'fp-performance-suite'); ?></button>
+                </p>
+            </form>
+            <?php if (!empty($results)) : ?>
+                <table class="fp-ps-table">
+                    <thead>
+                    <tr>
+                        <th><?php esc_html_e('Task', 'fp-performance-suite'); ?></th>
+                        <th><?php esc_html_e('Found', 'fp-performance-suite'); ?></th>
+                        <th><?php esc_html_e('Deleted', 'fp-performance-suite'); ?></th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <?php foreach ($results as $task => $data) : ?>
+                        <tr>
+                            <td><?php echo esc_html($tasks[$task] ?? $task); ?></td>
+                            <td><?php echo esc_html((string) ($data['found'] ?? 0)); ?></td>
+                            <td><?php echo esc_html((string) ($data['deleted'] ?? ($data['tables'] ?? '-'))); ?></td>
+                        </tr>
+                    <?php endforeach; ?>
+                    </tbody>
+                </table>
+            <?php endif; ?>
+        </section>
+        <?php
+        return (string) ob_get_clean();
+    }
+}

--- a/fp-performance-suite/src/Admin/Pages/Logs.php
+++ b/fp-performance-suite/src/Admin/Pages/Logs.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace FP\PerfSuite\Admin\Pages;
+
+use FP\PerfSuite\Services\Logs\DebugToggler;
+use function __;
+use function checked;
+use function esc_attr;
+use function esc_attr_e;
+use function esc_html;
+use function esc_html_e;
+use function wp_create_nonce;
+use function wp_nonce_field;
+use function wp_unslash;
+use function wp_verify_nonce;
+
+class Logs extends AbstractPage
+{
+    public function slug(): string
+    {
+        return 'fp-performance-suite-logs';
+    }
+
+    public function title(): string
+    {
+        return __('Realtime Log Center', 'fp-performance-suite');
+    }
+
+    public function capability(): string
+    {
+        return 'manage_options';
+    }
+
+    public function view(): string
+    {
+        return FP_PERF_SUITE_DIR . '/views/admin-page.php';
+    }
+
+    protected function data(): array
+    {
+        return [
+            'title' => $this->title(),
+            'breadcrumbs' => [__('Monitoring', 'fp-performance-suite'), __('Logs', 'fp-performance-suite')],
+        ];
+    }
+
+    protected function content(): string
+    {
+        $toggler = $this->container->get(DebugToggler::class);
+        $status = $toggler->status();
+        $message = '';
+        if ('POST' === $_SERVER['REQUEST_METHOD'] && isset($_POST['fp_ps_logs_nonce']) && wp_verify_nonce(wp_unslash($_POST['fp_ps_logs_nonce']), 'fp-ps-logs')) {
+            if (isset($_POST['toggle_debug'])) {
+                $enabled = !empty($_POST['wp_debug']);
+                $log = !empty($_POST['wp_debug_log']);
+                if ($toggler->toggle($enabled, $log)) {
+                    $message = __('Debug configuration updated.', 'fp-performance-suite');
+                    $status = $toggler->status();
+                } else {
+                    $message = __('Unable to update wp-config.php. Check file permissions.', 'fp-performance-suite');
+                }
+            }
+            if (isset($_POST['revert_debug'])) {
+                if ($toggler->revertLatest()) {
+                    $message = __('wp-config.php reverted from backup.', 'fp-performance-suite');
+                    $status = $toggler->status();
+                } else {
+                    $message = __('No backup available to revert.', 'fp-performance-suite');
+                }
+            }
+        }
+        $nonce = wp_create_nonce('wp_rest');
+        ob_start();
+        ?>
+        <?php if ($message) : ?>
+            <div class="notice notice-info"><p><?php echo esc_html($message); ?></p></div>
+        <?php endif; ?>
+        <section class="fp-ps-grid two">
+            <div class="fp-ps-card">
+                <h2><?php esc_html_e('Debug Toggles', 'fp-performance-suite'); ?></h2>
+                <form method="post">
+                    <?php wp_nonce_field('fp-ps-logs', 'fp_ps_logs_nonce'); ?>
+                    <input type="hidden" name="toggle_debug" value="1" />
+                    <label class="fp-ps-toggle">
+                        <span class="info">
+                            <strong><?php esc_html_e('Enable WP_DEBUG', 'fp-performance-suite'); ?></strong>
+                            <span class="fp-ps-badge red"><?php esc_html_e('Red', 'fp-performance-suite'); ?></span>
+                        </span>
+                        <input type="checkbox" name="wp_debug" value="1" <?php checked($status['WP_DEBUG']); ?> data-risk="red" />
+                    </label>
+                    <label class="fp-ps-toggle">
+                        <span class="info">
+                            <strong><?php esc_html_e('Enable debug.log', 'fp-performance-suite'); ?></strong>
+                            <span class="fp-ps-badge amber"><?php esc_html_e('Amber', 'fp-performance-suite'); ?></span>
+                        </span>
+                        <input type="checkbox" name="wp_debug_log" value="1" <?php checked($status['WP_DEBUG_LOG']); ?> data-risk="amber" />
+                    </label>
+                    <p>
+                        <button type="submit" class="button button-primary" data-risk="red"><?php esc_html_e('Save Debug Settings', 'fp-performance-suite'); ?></button>
+                    </p>
+                </form>
+                <form method="post" style="margin-top:1em;">
+                    <?php wp_nonce_field('fp-ps-logs', 'fp_ps_logs_nonce'); ?>
+                    <input type="hidden" name="revert_debug" value="1" />
+                    <button type="submit" class="button" data-risk="red"><?php esc_html_e('Revert to Backup', 'fp-performance-suite'); ?></button>
+                </form>
+                <?php if (!empty($status['log_file'])) : ?>
+                    <p><?php esc_html_e('Log file:', 'fp-performance-suite'); ?> <code><?php echo esc_html($status['log_file']); ?></code></p>
+                <?php endif; ?>
+            </div>
+            <div class="fp-ps-card">
+                <h2><?php esc_html_e('Realtime Viewer', 'fp-performance-suite'); ?></h2>
+                <p><?php esc_html_e('Filtered tail of debug.log with live updates every 2 seconds.', 'fp-performance-suite'); ?></p>
+                <div class="fp-ps-actions">
+                    <label><?php esc_html_e('Level', 'fp-performance-suite'); ?>
+                        <select data-fp-log-filter>
+                            <option value=""><?php esc_html_e('All', 'fp-performance-suite'); ?></option>
+                            <option value="notice"><?php esc_html_e('Notice', 'fp-performance-suite'); ?></option>
+                            <option value="warning"><?php esc_html_e('Warning', 'fp-performance-suite'); ?></option>
+                            <option value="error"><?php esc_html_e('Error', 'fp-performance-suite'); ?></option>
+                        </select>
+                    </label>
+                    <label><?php esc_html_e('Search', 'fp-performance-suite'); ?>
+                        <input type="search" data-fp-log-search placeholder="<?php esc_attr_e('Keyword', 'fp-performance-suite'); ?>" />
+                    </label>
+                </div>
+                <pre class="fp-ps-log-viewer" data-fp-logs data-nonce="<?php echo esc_attr($nonce); ?>" data-lines="200"></pre>
+            </div>
+        </section>
+        <?php
+        return (string) ob_get_clean();
+    }
+}

--- a/fp-performance-suite/src/Admin/Pages/Media.php
+++ b/fp-performance-suite/src/Admin/Pages/Media.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace FP\PerfSuite\Admin\Pages;
+
+use FP\PerfSuite\Services\Media\WebPConverter;
+use function __;
+use function checked;
+use function esc_attr;
+use function esc_html;
+use function esc_html__;
+use function esc_html_e;
+use function wp_nonce_field;
+use function wp_unslash;
+use function wp_verify_nonce;
+use function number_format_i18n;
+use function printf;
+
+class Media extends AbstractPage
+{
+    public function slug(): string
+    {
+        return 'fp-performance-suite-media';
+    }
+
+    public function title(): string
+    {
+        return __('Media Optimization', 'fp-performance-suite');
+    }
+
+    public function capability(): string
+    {
+        return 'manage_options';
+    }
+
+    public function view(): string
+    {
+        return FP_PERF_SUITE_DIR . '/views/admin-page.php';
+    }
+
+    protected function data(): array
+    {
+        return [
+            'title' => $this->title(),
+            'breadcrumbs' => [__('Optimization', 'fp-performance-suite'), __('Media', 'fp-performance-suite')],
+        ];
+    }
+
+    protected function content(): string
+    {
+        $converter = $this->container->get(WebPConverter::class);
+        $message = '';
+        $bulkResult = null;
+        if ('POST' === $_SERVER['REQUEST_METHOD'] && isset($_POST['fp_ps_media_nonce']) && wp_verify_nonce(wp_unslash($_POST['fp_ps_media_nonce']), 'fp-ps-media')) {
+            if (isset($_POST['save_webp'])) {
+                $converter->update([
+                    'enabled' => !empty($_POST['webp_enabled']),
+                    'quality' => (int) ($_POST['webp_quality'] ?? 82),
+                    'keep_original' => !empty($_POST['keep_original']),
+                    'lossy' => !empty($_POST['lossy']),
+                ]);
+                $message = __('WebP settings saved.', 'fp-performance-suite');
+            }
+            if (isset($_POST['bulk_convert'])) {
+                $limit = (int) ($_POST['bulk_limit'] ?? 20);
+                $offset = (int) ($_POST['bulk_offset'] ?? 0);
+                $bulkResult = $converter->bulkConvert($limit, $offset);
+                $message = __('Bulk conversion completed.', 'fp-performance-suite');
+            }
+        }
+        $settings = $converter->settings();
+        $status = $converter->status();
+        ob_start();
+        ?>
+        <?php if ($message) : ?>
+            <div class="notice notice-success"><p><?php echo esc_html($message); ?></p></div>
+        <?php endif; ?>
+        <section class="fp-ps-card">
+            <h2><?php esc_html_e('WebP Conversion', 'fp-performance-suite'); ?></h2>
+            <form method="post">
+                <?php wp_nonce_field('fp-ps-media', 'fp_ps_media_nonce'); ?>
+                <input type="hidden" name="save_webp" value="1" />
+                <label class="fp-ps-toggle">
+                    <span class="info">
+                        <strong><?php esc_html_e('Enable WebP on upload', 'fp-performance-suite'); ?></strong>
+                        <span class="fp-ps-badge green"><?php esc_html_e('Green', 'fp-performance-suite'); ?></span>
+                    </span>
+                    <input type="checkbox" name="webp_enabled" value="1" <?php checked($settings['enabled']); ?> data-risk="green" />
+                </label>
+                <p>
+                    <label for="webp_quality"><?php esc_html_e('Quality (0-100)', 'fp-performance-suite'); ?></label>
+                    <input type="number" name="webp_quality" id="webp_quality" value="<?php echo esc_attr((string) $settings['quality']); ?>" min="10" max="100" />
+                </p>
+                <label class="fp-ps-toggle">
+                    <span class="info">
+                        <strong><?php esc_html_e('Keep original files', 'fp-performance-suite'); ?></strong>
+                        <span class="fp-ps-badge amber"><?php esc_html_e('Amber', 'fp-performance-suite'); ?></span>
+                    </span>
+                    <input type="checkbox" name="keep_original" value="1" <?php checked($settings['keep_original']); ?> data-risk="amber" />
+                </label>
+                <label class="fp-ps-toggle">
+                    <span class="info">
+                        <strong><?php esc_html_e('Use lossy compression', 'fp-performance-suite'); ?></strong>
+                        <span class="fp-ps-badge amber"><?php esc_html_e('Amber', 'fp-performance-suite'); ?></span>
+                    </span>
+                    <input type="checkbox" name="lossy" value="1" <?php checked($settings['lossy']); ?> data-risk="amber" />
+                </label>
+                <p>
+                    <button type="submit" class="button button-primary"><?php esc_html_e('Save Media Settings', 'fp-performance-suite'); ?></button>
+                </p>
+            </form>
+            <p class="description"><?php printf(esc_html__('Current WebP coverage: %s%%', 'fp-performance-suite'), number_format_i18n($status['coverage'], 2)); ?></p>
+        </section>
+        <section class="fp-ps-card">
+            <h2><?php esc_html_e('Bulk Convert Library', 'fp-performance-suite'); ?></h2>
+            <form method="post">
+                <?php wp_nonce_field('fp-ps-media', 'fp_ps_media_nonce'); ?>
+                <input type="hidden" name="bulk_convert" value="1" />
+                <p>
+                    <label for="bulk_limit"><?php esc_html_e('Items per batch', 'fp-performance-suite'); ?></label>
+                    <input type="number" name="bulk_limit" id="bulk_limit" value="20" min="5" max="200" />
+                </p>
+                <p>
+                    <label for="bulk_offset"><?php esc_html_e('Offset', 'fp-performance-suite'); ?></label>
+                    <input type="number" name="bulk_offset" id="bulk_offset" value="0" min="0" />
+                </p>
+                <p>
+                    <button type="submit" class="button" data-risk="amber"><?php esc_html_e('Run Bulk Conversion', 'fp-performance-suite'); ?></button>
+                </p>
+            </form>
+            <?php if ($bulkResult) : ?>
+                <p><?php printf(esc_html__('%1$d items processed out of %2$d.', 'fp-performance-suite'), (int) $bulkResult['converted'], (int) $bulkResult['total']); ?></p>
+            <?php endif; ?>
+        </section>
+        <?php
+        return (string) ob_get_clean();
+    }
+}

--- a/fp-performance-suite/src/Admin/Pages/Presets.php
+++ b/fp-performance-suite/src/Admin/Pages/Presets.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace FP\PerfSuite\Admin\Pages;
+
+use FP\PerfSuite\Services\Presets\Manager as PresetManager;
+use function __;
+use function esc_attr;
+use function esc_html;
+use function esc_html_e;
+use function esc_url;
+use function rest_url;
+use function str_replace;
+use function ucfirst;
+use function wp_json_encode;
+use function wp_create_nonce;
+
+class Presets extends AbstractPage
+{
+    public function slug(): string
+    {
+        return 'fp-performance-suite-presets';
+    }
+
+    public function title(): string
+    {
+        return __('Preset Bundles', 'fp-performance-suite');
+    }
+
+    public function capability(): string
+    {
+        return 'manage_options';
+    }
+
+    public function view(): string
+    {
+        return FP_PERF_SUITE_DIR . '/views/admin-page.php';
+    }
+
+    protected function data(): array
+    {
+        return [
+            'title' => $this->title(),
+            'breadcrumbs' => [__('Optimization', 'fp-performance-suite'), __('Presets', 'fp-performance-suite')],
+        ];
+    }
+
+    protected function content(): string
+    {
+        $manager = $this->container->get(PresetManager::class);
+        $presets = $manager->presets();
+        $active = $manager->getActivePreset();
+        $nonce = wp_create_nonce('wp_rest');
+        ob_start();
+        ?>
+        <section class="fp-ps-grid three">
+            <?php foreach ($presets as $key => $preset) : ?>
+                <article class="fp-ps-card">
+                    <header>
+                        <h2><?php echo esc_html($preset['label']); ?></h2>
+                        <?php if ($active === $key) : ?>
+                            <span class="fp-ps-badge green"><?php esc_html_e('Active', 'fp-performance-suite'); ?></span>
+                        <?php endif; ?>
+                    </header>
+                    <p><?php esc_html_e('Safe defaults crafted for shared hosting providers.', 'fp-performance-suite'); ?></p>
+                    <ul>
+                        <?php foreach ($preset['config'] as $section => $config) : ?>
+                            <li><strong><?php echo esc_html(ucfirst(str_replace('_', ' ', $section))); ?>:</strong> <?php echo esc_html(wp_json_encode($config)); ?></li>
+                        <?php endforeach; ?>
+                    </ul>
+                    <div class="fp-ps-actions">
+                        <button class="button button-primary" data-fp-preset="<?php echo esc_attr($key); ?>" data-fp-nonce="<?php echo esc_attr($nonce); ?>" data-risk="amber"><?php esc_html_e('Apply Preset', 'fp-performance-suite'); ?></button>
+                        <?php if ($active === $key) : ?>
+                            <form method="post" action="<?php echo esc_url(rest_url('fp-ps/v1/preset/rollback')); ?>">
+                                <input type="hidden" name="_wpnonce" value="<?php echo esc_attr($nonce); ?>" />
+                                <button type="submit" class="button" data-risk="amber"><?php esc_html_e('Rollback', 'fp-performance-suite'); ?></button>
+                            </form>
+                        <?php endif; ?>
+                    </div>
+                </article>
+            <?php endforeach; ?>
+        </section>
+        <?php
+        return (string) ob_get_clean();
+    }
+}

--- a/fp-performance-suite/src/Admin/Pages/Settings.php
+++ b/fp-performance-suite/src/Admin/Pages/Settings.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace FP\PerfSuite\Admin\Pages;
+
+use function __;
+use function esc_attr;
+use function esc_attr_e;
+use function esc_html;
+use function esc_html_e;
+use function esc_textarea;
+use function get_option;
+use function sanitize_text_field;
+use function selected;
+use function checked;
+use function update_option;
+use function wp_nonce_field;
+use function wp_unslash;
+use function wp_verify_nonce;
+
+class Settings extends AbstractPage
+{
+    public function slug(): string
+    {
+        return 'fp-performance-suite-settings';
+    }
+
+    public function title(): string
+    {
+        return __('Settings', 'fp-performance-suite');
+    }
+
+    public function capability(): string
+    {
+        return 'manage_options';
+    }
+
+    public function view(): string
+    {
+        return FP_PERF_SUITE_DIR . '/views/admin-page.php';
+    }
+
+    protected function data(): array
+    {
+        return [
+            'title' => $this->title(),
+            'breadcrumbs' => [__('Configuration', 'fp-performance-suite')],
+        ];
+    }
+
+    protected function content(): string
+    {
+        $options = get_option('fp_ps_settings', [
+            'allowed_role' => 'administrator',
+            'safety_mode' => true,
+        ]);
+        $criticalCss = get_option('fp_ps_critical_css', '');
+        $message = '';
+        if ('POST' === $_SERVER['REQUEST_METHOD'] && isset($_POST['fp_ps_settings_nonce']) && wp_verify_nonce(wp_unslash($_POST['fp_ps_settings_nonce']), 'fp-ps-settings')) {
+            $options['allowed_role'] = sanitize_text_field($_POST['allowed_role'] ?? 'administrator');
+            $options['safety_mode'] = !empty($_POST['safety_mode']);
+            update_option('fp_ps_settings', $options);
+            update_option('fp_ps_critical_css', wp_unslash($_POST['critical_css'] ?? ''));
+            $message = __('Settings saved.', 'fp-performance-suite');
+        }
+        ob_start();
+        ?>
+        <?php if ($message) : ?>
+            <div class="notice notice-success"><p><?php echo esc_html($message); ?></p></div>
+        <?php endif; ?>
+        <section class="fp-ps-card">
+            <h2><?php esc_html_e('Access Control', 'fp-performance-suite'); ?></h2>
+            <form method="post">
+                <?php wp_nonce_field('fp-ps-settings', 'fp_ps_settings_nonce'); ?>
+                <p>
+                    <label for="allowed_role"><?php esc_html_e('Minimum role to manage plugin', 'fp-performance-suite'); ?></label>
+                    <select name="allowed_role" id="allowed_role">
+                        <option value="administrator" <?php selected($options['allowed_role'], 'administrator'); ?>><?php esc_html_e('Administrator', 'fp-performance-suite'); ?></option>
+                        <option value="editor" <?php selected($options['allowed_role'], 'editor'); ?>><?php esc_html_e('Editor', 'fp-performance-suite'); ?></option>
+                    </select>
+                </p>
+                <label class="fp-ps-toggle">
+                    <span class="info">
+                        <strong><?php esc_html_e('Safety mode', 'fp-performance-suite'); ?></strong>
+                        <span class="fp-ps-badge green"><?php esc_html_e('Green', 'fp-performance-suite'); ?></span>
+                    </span>
+                    <input type="checkbox" name="safety_mode" value="1" <?php checked($options['safety_mode']); ?> />
+                </label>
+                <p>
+                    <label for="critical_css"><?php esc_html_e('Critical CSS placeholder', 'fp-performance-suite'); ?></label>
+                    <textarea name="critical_css" id="critical_css" rows="6" class="large-text code" placeholder="<?php esc_attr_e('Paste above-the-fold CSS or snippet reference.', 'fp-performance-suite'); ?>"><?php echo esc_textarea($criticalCss); ?></textarea>
+                </p>
+                <p><button type="submit" class="button button-primary"><?php esc_html_e('Save Settings', 'fp-performance-suite'); ?></button></p>
+            </form>
+        </section>
+        <?php
+        return (string) ob_get_clean();
+    }
+}

--- a/fp-performance-suite/src/Admin/Pages/Tools.php
+++ b/fp-performance-suite/src/Admin/Pages/Tools.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace FP\PerfSuite\Admin\Pages;
+
+use FP\PerfSuite\Services\Assets\Optimizer;
+use FP\PerfSuite\Services\Cache\Headers;
+use FP\PerfSuite\Services\Cache\PageCache;
+use FP\PerfSuite\Services\DB\Cleaner;
+use FP\PerfSuite\Services\Media\WebPConverter;
+use function __;
+use function esc_attr;
+use function esc_attr_e;
+use function esc_html;
+use function esc_html_e;
+use function esc_textarea;
+use function json_decode;
+use function json_encode;
+use function wp_json_encode;
+use function wp_nonce_field;
+use function wp_unslash;
+use function wp_verify_nonce;
+use function is_array;
+use function sprintf;
+use function update_option;
+
+class Tools extends AbstractPage
+{
+    public function slug(): string
+    {
+        return 'fp-performance-suite-tools';
+    }
+
+    public function title(): string
+    {
+        return __('Tools & Export', 'fp-performance-suite');
+    }
+
+    public function capability(): string
+    {
+        return 'manage_options';
+    }
+
+    public function view(): string
+    {
+        return FP_PERF_SUITE_DIR . '/views/admin-page.php';
+    }
+
+    protected function data(): array
+    {
+        return [
+            'title' => $this->title(),
+            'breadcrumbs' => [__('Tools', 'fp-performance-suite')],
+        ];
+    }
+
+    protected function content(): string
+    {
+        $pageCache = $this->container->get(PageCache::class);
+        $headers = $this->container->get(Headers::class);
+        $webp = $this->container->get(WebPConverter::class);
+        $optimizer = $this->container->get(Optimizer::class);
+        $cleaner = $this->container->get(Cleaner::class);
+        $message = '';
+        $importStatus = '';
+        if ('POST' === $_SERVER['REQUEST_METHOD'] && isset($_POST['fp_ps_tools_nonce'])) {
+            $nonce = wp_unslash($_POST['fp_ps_tools_nonce']);
+            if (!is_string($nonce) || !wp_verify_nonce($nonce, 'fp-ps-tools')) {
+                $message = __('Security check failed. Please try again.', 'fp-performance-suite');
+            } elseif (isset($_POST['import_json'])) {
+                $json = wp_unslash($_POST['settings_json'] ?? '');
+                $data = json_decode($json, true);
+                if (is_array($data)) {
+                    $allowed = [
+                        'fp_ps_page_cache',
+                        'fp_ps_browser_cache',
+                        'fp_ps_assets',
+                        'fp_ps_webp',
+                        'fp_ps_db',
+                    ];
+                    foreach ($allowed as $option) {
+                        if (array_key_exists($option, $data)) {
+                            update_option($option, $data[$option]);
+                        }
+                    }
+                    $importStatus = __('Settings imported successfully.', 'fp-performance-suite');
+                } else {
+                    $importStatus = __('Invalid JSON payload.', 'fp-performance-suite');
+                }
+            }
+        }
+
+        $export = [
+            'fp_ps_page_cache' => $pageCache->settings(),
+            'fp_ps_browser_cache' => $headers->settings(),
+            'fp_ps_assets' => $optimizer->settings(),
+            'fp_ps_webp' => $webp->settings(),
+            'fp_ps_db' => $cleaner->settings(),
+        ];
+        $tests = [
+            __('Page cache enabled', 'fp-performance-suite') => $pageCache->isEnabled() ? __('Pass', 'fp-performance-suite') : __('Disabled', 'fp-performance-suite'),
+            __('Browser cache headers', 'fp-performance-suite') => $headers->status()['enabled'] ? __('Pass', 'fp-performance-suite') : __('Missing', 'fp-performance-suite'),
+            __('WebP coverage', 'fp-performance-suite') => sprintf('%0.2f%%', $webp->status()['coverage']),
+        ];
+
+        ob_start();
+        ?>
+        <?php if ($message) : ?>
+            <div class="notice notice-info"><p><?php echo esc_html($message); ?></p></div>
+        <?php endif; ?>
+        <section class="fp-ps-card">
+            <h2><?php esc_html_e('Export Settings', 'fp-performance-suite'); ?></h2>
+            <textarea class="large-text code" rows="8" readonly><?php echo esc_textarea(wp_json_encode($export, JSON_PRETTY_PRINT)); ?></textarea>
+        </section>
+        <section class="fp-ps-card">
+            <h2><?php esc_html_e('Import Settings', 'fp-performance-suite'); ?></h2>
+            <?php if ($importStatus) : ?>
+                <div class="notice notice-info"><p><?php echo esc_html($importStatus); ?></p></div>
+            <?php endif; ?>
+            <form method="post">
+                <?php wp_nonce_field('fp-ps-tools', 'fp_ps_tools_nonce'); ?>
+                <textarea name="settings_json" rows="6" class="large-text code" placeholder="<?php esc_attr_e('Paste JSON export here', 'fp-performance-suite'); ?>"></textarea>
+                <p><button type="submit" name="import_json" value="1" class="button" data-risk="amber"><?php esc_html_e('Import JSON', 'fp-performance-suite'); ?></button></p>
+            </form>
+        </section>
+        <section class="fp-ps-card">
+            <h2><?php esc_html_e('Diagnostics', 'fp-performance-suite'); ?></h2>
+            <ul>
+                <?php foreach ($tests as $label => $value) : ?>
+                    <li><strong><?php echo esc_html($label); ?>:</strong> <?php echo esc_html($value); ?></li>
+                <?php endforeach; ?>
+            </ul>
+        </section>
+        <?php
+        return (string) ob_get_clean();
+    }
+}

--- a/fp-performance-suite/src/Http/Routes.php
+++ b/fp-performance-suite/src/Http/Routes.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace FP\PerfSuite\Http;
+
+use FP\PerfSuite\ServiceContainer;
+use FP\PerfSuite\Services\DB\Cleaner;
+use FP\PerfSuite\Services\Logs\DebugToggler;
+use FP\PerfSuite\Services\Logs\RealtimeLog;
+use FP\PerfSuite\Services\Presets\Manager as PresetManager;
+use FP\PerfSuite\Services\Score\Scorer;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_Error;
+use function esc_html__;
+
+class Routes
+{
+    private ServiceContainer $container;
+
+    public function __construct(ServiceContainer $container)
+    {
+        $this->container = $container;
+    }
+
+    public function boot(): void
+    {
+        add_action('rest_api_init', [$this, 'register']);
+    }
+
+    public function register(): void
+    {
+        register_rest_route('fp-ps/v1', '/logs/tail', [
+            'methods' => 'GET',
+            'callback' => [$this, 'logsTail'],
+            'permission_callback' => [$this, 'permissionCheck'],
+            'args' => [
+                'lines' => ['default' => 200],
+                'level' => ['default' => ''],
+                'query' => ['default' => ''],
+            ],
+        ]);
+
+        register_rest_route('fp-ps/v1', '/debug/toggle', [
+            'methods' => 'POST',
+            'callback' => [$this, 'debugToggle'],
+            'permission_callback' => [$this, 'permissionCheck'],
+        ]);
+
+        register_rest_route('fp-ps/v1', '/preset/apply', [
+            'methods' => 'POST',
+            'callback' => [$this, 'presetApply'],
+            'permission_callback' => [$this, 'permissionCheck'],
+        ]);
+
+        register_rest_route('fp-ps/v1', '/preset/rollback', [
+            'methods' => 'POST',
+            'callback' => [$this, 'presetRollback'],
+            'permission_callback' => [$this, 'permissionCheck'],
+        ]);
+
+        register_rest_route('fp-ps/v1', '/db/cleanup', [
+            'methods' => 'POST',
+            'callback' => [$this, 'dbCleanup'],
+            'permission_callback' => [$this, 'permissionCheck'],
+        ]);
+
+        register_rest_route('fp-ps/v1', '/score', [
+            'methods' => 'GET',
+            'callback' => [$this, 'score'],
+            'permission_callback' => [$this, 'permissionCheck'],
+        ]);
+
+        register_rest_route('fp-ps/v1', '/progress', [
+            'methods' => 'GET',
+            'callback' => [$this, 'progress'],
+            'permission_callback' => '__return_true',
+        ]);
+    }
+
+    public function permissionCheck(WP_REST_Request $request): bool
+    {
+        if (!current_user_can('manage_options')) {
+            return false;
+        }
+        $nonce = $request->get_header('X-WP-Nonce');
+        return (bool) wp_verify_nonce($nonce, 'wp_rest');
+    }
+
+    public function logsTail(WP_REST_Request $request)
+    {
+        $lines = (int) $request->get_param('lines');
+        $level = (string) $request->get_param('level');
+        $query = (string) $request->get_param('query');
+        $log = $this->container->get(RealtimeLog::class);
+        $data = $log->tail($lines, $level, $query);
+        return rest_ensure_response(['data' => $data]);
+    }
+
+    public function debugToggle(WP_REST_Request $request)
+    {
+        $enabled = (bool) $request->get_param('enabled');
+        $log = (bool) $request->get_param('log');
+        $toggler = $this->container->get(DebugToggler::class);
+        $result = $toggler->toggle($enabled, $log);
+        if (!$result) {
+            return new WP_Error('fp_ps_debug', esc_html__('Unable to toggle debug mode.', 'fp-performance-suite'));
+        }
+        return rest_ensure_response(['success' => true, 'status' => $toggler->status()]);
+    }
+
+    public function presetApply(WP_REST_Request $request)
+    {
+        $id = sanitize_key($request->get_param('id'));
+        $manager = $this->container->get(PresetManager::class);
+        $result = $manager->apply($id);
+        return rest_ensure_response($result);
+    }
+
+    public function presetRollback(): WP_REST_Response
+    {
+        $manager = $this->container->get(PresetManager::class);
+        $result = $manager->rollback();
+        return rest_ensure_response(['success' => $result]);
+    }
+
+    public function dbCleanup(WP_REST_Request $request)
+    {
+        $scope = (array) $request->get_param('scope');
+        $dry = filter_var($request->get_param('dryRun'), FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+        $dry = $dry === null ? true : $dry;
+        $batch = $request->get_param('batch');
+        $batch = $batch ? (int) $batch : null;
+        $cleaner = $this->container->get(Cleaner::class);
+        $result = $cleaner->cleanup($scope, $dry, $batch);
+        return rest_ensure_response($result);
+    }
+
+    public function score(): WP_REST_Response
+    {
+        $scorer = $this->container->get(Scorer::class);
+        return rest_ensure_response($scorer->calculate());
+    }
+
+    public function progress(): WP_REST_Response
+    {
+        $file = FP_PERF_SUITE_DIR . '/../.codex-state.json';
+        if (!file_exists($file)) {
+            return rest_ensure_response([]);
+        }
+        $data = json_decode((string) file_get_contents($file), true);
+        if (!is_array($data)) {
+            $data = [];
+        }
+        return rest_ensure_response($data);
+    }
+}

--- a/fp-performance-suite/src/Plugin.php
+++ b/fp-performance-suite/src/Plugin.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace FP\PerfSuite;
+
+use FP\PerfSuite\Admin\Assets as AdminAssets;
+use FP\PerfSuite\Admin\Menu;
+use FP\PerfSuite\Http\Routes;
+use FP\PerfSuite\Services\Assets\Optimizer;
+use FP\PerfSuite\Services\Cache\Headers;
+use FP\PerfSuite\Services\Cache\PageCache;
+use FP\PerfSuite\Services\DB\Cleaner;
+use FP\PerfSuite\Services\Logs\DebugToggler;
+use FP\PerfSuite\Services\Logs\RealtimeLog;
+use FP\PerfSuite\Services\Media\WebPConverter;
+use FP\PerfSuite\Services\Presets\Manager as PresetManager;
+use FP\PerfSuite\Services\Score\Scorer;
+use FP\PerfSuite\Utils\Env;
+use FP\PerfSuite\Utils\Fs;
+use FP\PerfSuite\Utils\Htaccess;
+use FP\PerfSuite\Utils\Semaphore;
+use function wp_clear_scheduled_hook;
+
+class Plugin
+{
+    private static ?ServiceContainer $container = null;
+
+    public static function init(): void
+    {
+        if (self::$container instanceof ServiceContainer) {
+            return;
+        }
+
+        $container = new ServiceContainer();
+        self::register($container);
+        self::$container = $container;
+
+        do_action('fp_perfsuite_container_ready', $container);
+
+        $container->get(Menu::class)->boot();
+        $container->get(AdminAssets::class)->boot();
+        $container->get(Routes::class)->boot();
+
+        add_action('init', static function () use ($container) {
+            load_plugin_textdomain('fp-performance-suite', false, dirname(plugin_basename(FP_PERF_SUITE_FILE)) . '/languages');
+            $container->get(PageCache::class)->register();
+            $container->get(Headers::class)->register();
+            $container->get(Optimizer::class)->register();
+            $container->get(WebPConverter::class)->register();
+            $container->get(Cleaner::class)->register();
+        });
+    }
+
+    private static function register(ServiceContainer $container): void
+    {
+        if (!defined('FP_PERF_SUITE_FILE')) {
+            define('FP_PERF_SUITE_FILE', __DIR__ . '/../fp-performance-suite.php');
+        }
+
+        $container->set(ServiceContainer::class, static fn() => $container);
+
+        $container->set(Fs::class, static function () {
+            return new Fs();
+        });
+
+        $container->set(Htaccess::class, static function (ServiceContainer $c) {
+            return new Htaccess($c->get(Fs::class));
+        });
+
+        $container->set(Env::class, static fn() => new Env());
+        $container->set(Semaphore::class, static fn() => new Semaphore());
+
+        $container->set(PageCache::class, static fn(ServiceContainer $c) => new PageCache($c->get(Fs::class), $c->get(Env::class)));
+        $container->set(Headers::class, static fn(ServiceContainer $c) => new Headers($c->get(Htaccess::class), $c->get(Env::class)));
+        $container->set(Optimizer::class, static fn(ServiceContainer $c) => new Optimizer($c->get(Semaphore::class)));
+        $container->set(WebPConverter::class, static fn(ServiceContainer $c) => new WebPConverter($c->get(Fs::class)));
+        $container->set(Cleaner::class, static fn(ServiceContainer $c) => new Cleaner($c->get(Env::class)));
+        $container->set(DebugToggler::class, static fn(ServiceContainer $c) => new DebugToggler($c->get(Fs::class), $c->get(Env::class)));
+        $container->set(RealtimeLog::class, static fn(ServiceContainer $c) => new RealtimeLog($c->get(DebugToggler::class)));
+        $container->set(PresetManager::class, static function (ServiceContainer $c) {
+            return new PresetManager(
+                $c->get(PageCache::class),
+                $c->get(Headers::class),
+                $c->get(Optimizer::class),
+                $c->get(WebPConverter::class),
+                $c->get(Cleaner::class),
+                $c->get(DebugToggler::class)
+            );
+        });
+        $container->set(Scorer::class, static fn(ServiceContainer $c) => new Scorer($c->get(PageCache::class), $c->get(Headers::class), $c->get(Optimizer::class), $c->get(WebPConverter::class), $c->get(Cleaner::class), $c->get(DebugToggler::class)));
+
+        $container->set(AdminAssets::class, static fn() => new AdminAssets());
+        $container->set(Menu::class, static fn(ServiceContainer $c) => new Menu($c));
+        $container->set(Routes::class, static fn(ServiceContainer $c) => new Routes($c));
+    }
+
+    public static function container(): ServiceContainer
+    {
+        if (!self::$container instanceof ServiceContainer) {
+            self::init();
+        }
+
+        return self::$container;
+    }
+
+    public static function onActivate(): void
+    {
+        update_option('fp_perfsuite_version', '1.0.0');
+        $cleaner = new Cleaner(new Env());
+        $cleaner->primeSchedules();
+        $cleaner->maybeSchedule(true);
+    }
+
+    public static function onDeactivate(): void
+    {
+        wp_clear_scheduled_hook(Cleaner::CRON_HOOK);
+    }
+}

--- a/fp-performance-suite/src/ServiceContainer.php
+++ b/fp-performance-suite/src/ServiceContainer.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace FP\PerfSuite;
+
+use RuntimeException;
+
+class ServiceContainer
+{
+    /** @var array<string, callable|object> */
+    private array $bindings = [];
+
+    /**
+     * @param string $id
+     * @param callable $factory
+     */
+    public function set(string $id, callable $factory): void
+    {
+        $this->bindings[$id] = $factory;
+    }
+
+    /**
+     * @template T
+     * @param class-string<T>|string $id
+     * @return T|mixed
+     */
+    public function get(string $id)
+    {
+        if (!array_key_exists($id, $this->bindings)) {
+            throw new RuntimeException(sprintf('Service "%s" not found.', $id));
+        }
+
+        $service = $this->bindings[$id];
+        if (is_callable($service)) {
+            $this->bindings[$id] = $service = $service($this);
+        }
+
+        return $service;
+    }
+
+    public function has(string $id): bool
+    {
+        return array_key_exists($id, $this->bindings);
+    }
+}

--- a/fp-performance-suite/src/Services/Assets/Optimizer.php
+++ b/fp-performance-suite/src/Services/Assets/Optimizer.php
@@ -1,0 +1,219 @@
+<?php
+
+namespace FP\PerfSuite\Services\Assets;
+
+use FP\PerfSuite\Utils\Semaphore;
+use function __;
+
+class Optimizer
+{
+    private const OPTION = 'fp_ps_assets';
+    private Semaphore $semaphore;
+    private bool $bufferStarted = false;
+
+    public function __construct(Semaphore $semaphore)
+    {
+        $this->semaphore = $semaphore;
+    }
+
+    public function register(): void
+    {
+        $settings = $this->settings();
+        if (!is_admin()) {
+            if (!empty($settings['minify_html'])) {
+                add_action('template_redirect', [$this, 'startBuffer'], 1);
+                add_action('shutdown', [$this, 'endBuffer'], PHP_INT_MAX);
+            }
+            if (!empty($settings['defer_js'])) {
+                add_filter('script_loader_tag', [$this, 'filterScriptTag'], 10, 3);
+            }
+            if (!empty($settings['dns_prefetch'])) {
+                add_filter('wp_resource_hints', [$this, 'dnsPrefetch'], 10, 2);
+            }
+            if (!empty($settings['preload'])) {
+                add_filter('wp_resource_hints', [$this, 'preloadResources'], 10, 2);
+            }
+        }
+
+        if (!empty($settings['remove_emojis'])) {
+            $this->disableEmojis();
+        }
+
+        if (!empty($settings['heartbeat_admin'])) {
+            add_filter('heartbeat_settings', [$this, 'heartbeatSettings']);
+        }
+    }
+
+    /**
+     * @return array{
+     *  minify_html:bool,
+     *  defer_js:bool,
+     *  async_js:bool,
+     *  remove_emojis:bool,
+     *  dns_prefetch:array<int,string>,
+     *  preload:array<int,string>,
+     *  heartbeat_admin:int,
+     *  combine_css:bool,
+     *  combine_js:bool
+     * }
+     */
+    public function settings(): array
+    {
+        $defaults = [
+            'minify_html' => false,
+            'defer_js' => true,
+            'async_js' => false,
+            'remove_emojis' => true,
+            'dns_prefetch' => [],
+            'preload' => [],
+            'heartbeat_admin' => 60,
+            'combine_css' => false,
+            'combine_js' => false,
+        ];
+        $options = get_option(self::OPTION, []);
+        $options['dns_prefetch'] = array_filter(array_map('esc_url_raw', $options['dns_prefetch'] ?? []));
+        $options['preload'] = array_filter(array_map('esc_url_raw', $options['preload'] ?? []));
+        return wp_parse_args($options, $defaults);
+    }
+
+    public function update(array $settings): void
+    {
+        $current = $this->settings();
+        $new = [
+            'minify_html' => !empty($settings['minify_html']),
+            'defer_js' => !empty($settings['defer_js']),
+            'async_js' => !empty($settings['async_js']),
+            'remove_emojis' => !empty($settings['remove_emojis']),
+            'dns_prefetch' => array_filter(array_map('esc_url_raw', $settings['dns_prefetch'] ?? $current['dns_prefetch'])),
+            'preload' => array_filter(array_map('esc_url_raw', $settings['preload'] ?? $current['preload'])),
+            'heartbeat_admin' => isset($settings['heartbeat_admin']) ? (int) $settings['heartbeat_admin'] : $current['heartbeat_admin'],
+            'combine_css' => !empty($settings['combine_css']),
+            'combine_js' => !empty($settings['combine_js']),
+        ];
+        update_option(self::OPTION, $new);
+    }
+
+    public function startBuffer(): void
+    {
+        if ($this->bufferStarted) {
+            return;
+        }
+        ob_start([$this, 'minifyHtml']);
+        $this->bufferStarted = true;
+    }
+
+    public function endBuffer(): void
+    {
+        if (!$this->bufferStarted) {
+            return;
+        }
+        if (ob_get_level() > 0) {
+            ob_end_flush();
+        }
+        $this->bufferStarted = false;
+    }
+
+    public function minifyHtml(string $html): string
+    {
+        $search = [
+            '/\>[\n\r\t ]+/s',
+            '/[\n\r\t ]+\</s',
+            '/\s{2,}/',
+        ];
+        $replace = ['>', '<', ' '];
+        return preg_replace($search, $replace, $html) ?? $html;
+    }
+
+    public function filterScriptTag(string $tag, string $handle, string $src): string
+    {
+        $settings = $this->settings();
+        if (is_admin()) {
+            return $tag;
+        }
+        $skip = apply_filters('fp_ps_defer_skip_handles', ['jquery', 'jquery-core', 'jquery-migrate']);
+        if (in_array($handle, $skip, true)) {
+            return $tag;
+        }
+        if (!empty($settings['defer_js']) && strpos($tag, ' defer') === false) {
+            $tag = str_replace('<script ', '<script defer ', $tag);
+        }
+        if (!empty($settings['async_js']) && strpos($tag, ' async') === false) {
+            $tag = str_replace('<script ', '<script async ', $tag);
+        }
+        return $tag;
+    }
+
+    /**
+     * @param array<int,string> $hints
+     * @param string $relation
+     * @return array<int,string>
+     */
+    public function dnsPrefetch(array $hints, string $relation): array
+    {
+        if ('dns-prefetch' !== $relation) {
+            return $hints;
+        }
+        $settings = $this->settings();
+        return array_unique(array_merge($hints, $settings['dns_prefetch']));
+    }
+
+    /**
+     * @param array<int,string> $hints
+     * @param string $relation
+     * @return array<int,string>
+     */
+    public function preloadResources(array $hints, string $relation): array
+    {
+        if ('preload' !== $relation) {
+            return $hints;
+        }
+        $settings = $this->settings();
+        return array_unique(array_merge($hints, $settings['preload']));
+    }
+
+    /**
+     * @param array<string, mixed> $settings
+     * @return array<string, mixed>
+     */
+    public function heartbeatSettings(array $settings): array
+    {
+        $current = $this->settings();
+        $settings['interval'] = max(15, (int) $current['heartbeat_admin']);
+        return $settings;
+    }
+
+    private function disableEmojis(): void
+    {
+        remove_action('wp_head', 'print_emoji_detection_script', 7);
+        remove_action('wp_print_styles', 'print_emoji_styles');
+        remove_action('admin_print_scripts', 'print_emoji_detection_script');
+        remove_action('admin_print_styles', 'print_emoji_styles');
+        remove_filter('the_content_feed', 'wp_staticize_emoji');
+        remove_filter('comment_text_rss', 'wp_staticize_emoji');
+        remove_filter('wp_mail', 'wp_staticize_emoji_for_email');
+    }
+
+    public function status(): array
+    {
+        $settings = $this->settings();
+        return [
+            'minify_html' => !empty($settings['minify_html']),
+            'defer_js' => !empty($settings['defer_js']),
+            'async_js' => !empty($settings['async_js']),
+            'remove_emojis' => !empty($settings['remove_emojis']),
+            'heartbeat_admin' => (int) $settings['heartbeat_admin'],
+        ];
+    }
+
+    /**
+     * @return array<int, array<string, string>>
+     */
+    public function riskLevels(): array
+    {
+        return [
+            $this->semaphore->describe('remove_emojis', 'green', __('Disables emoji scripts to save requests.', 'fp-performance-suite')),
+            $this->semaphore->describe('defer_js', 'amber', __('Defers non-critical JavaScript to speed rendering.', 'fp-performance-suite')),
+            $this->semaphore->describe('combine_js', 'red', __('Combining scripts may break complex setups. Proceed with caution.', 'fp-performance-suite')),
+        ];
+    }
+}

--- a/fp-performance-suite/src/Services/Cache/Headers.php
+++ b/fp-performance-suite/src/Services/Cache/Headers.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace FP\PerfSuite\Services\Cache;
+
+use FP\PerfSuite\Utils\Env;
+use FP\PerfSuite\Utils\Htaccess;
+
+class Headers
+{
+    private const OPTION = 'fp_ps_browser_cache';
+    private Htaccess $htaccess;
+    private Env $env;
+
+    public function __construct(Htaccess $htaccess, Env $env)
+    {
+        $this->htaccess = $htaccess;
+        $this->env = $env;
+    }
+
+    public function register(): void
+    {
+        $settings = $this->settings();
+        if (empty($settings['enabled'])) {
+            return;
+        }
+
+        add_action('send_headers', function () use ($settings) {
+            foreach ($settings['headers'] as $header => $value) {
+                if (!headers_sent()) {
+                    header($header . ': ' . $value, true);
+                }
+            }
+        });
+
+        if (!empty($settings['htaccess']) && $this->env->isApache() && $this->htaccess->isSupported()) {
+            $this->applyHtaccess($settings['htaccess']);
+        }
+    }
+
+    /**
+     * @return array{enabled:bool,headers:array<string,string>,htaccess:string}
+     */
+    public function settings(): array
+    {
+        $defaults = [
+            'enabled' => false,
+            'headers' => [
+                'Cache-Control' => 'public, max-age=31536000',
+                'Expires' => gmdate('D, d M Y H:i:s', time() + 31536000) . ' GMT',
+            ],
+            'htaccess' => $this->defaultHtaccess(),
+        ];
+
+        $options = get_option(self::OPTION, []);
+        $options['headers'] = isset($options['headers']) ? (array) $options['headers'] : [];
+        return wp_parse_args($options, $defaults);
+    }
+
+    public function update(array $settings): void
+    {
+        $current = $this->settings();
+        $new = [
+            'enabled' => !empty($settings['enabled']),
+            'headers' => array_map('sanitize_text_field', $settings['headers'] ?? $current['headers']),
+            'htaccess' => isset($settings['htaccess']) ? sanitize_textarea_field($settings['htaccess']) : $current['htaccess'],
+        ];
+
+        update_option(self::OPTION, $new);
+
+        if (!$new['enabled']) {
+            $this->htaccess->removeSection('FP-Performance-Suite');
+        }
+    }
+
+    public function applyHtaccess(string $rules): void
+    {
+        $this->htaccess->injectRules('FP-Performance-Suite', $rules);
+    }
+
+    public function status(): array
+    {
+        $settings = $this->settings();
+        return [
+            'enabled' => !empty($settings['enabled']),
+            'headers' => $settings['headers'],
+            'htaccess_applied' => !empty($settings['enabled']) && $this->env->isApache(),
+        ];
+    }
+
+    private function defaultHtaccess(): string
+    {
+        return <<<HTACCESS
+<IfModule mod_expires.c>
+    ExpiresActive On
+    ExpiresByType image/webp "access plus 1 year"
+    ExpiresByType image/png "access plus 1 year"
+    ExpiresByType image/jpeg "access plus 1 year"
+    ExpiresByType text/css "access plus 1 month"
+    ExpiresByType application/javascript "access plus 1 month"
+</IfModule>
+
+<IfModule mod_headers.c>
+    <FilesMatch "\.(js|css|png|jpg|jpeg|gif|webp|svg)$">
+        Header set Cache-Control "public, max-age=2592000"
+    </FilesMatch>
+</IfModule>
+HTACCESS;
+    }
+}

--- a/fp-performance-suite/src/Services/Cache/PageCache.php
+++ b/fp-performance-suite/src/Services/Cache/PageCache.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace FP\PerfSuite\Services\Cache;
+
+use FP\PerfSuite\Utils\Env;
+use FP\PerfSuite\Utils\Fs;
+
+class PageCache
+{
+    private const OPTION = 'fp_ps_page_cache';
+    private Fs $fs;
+    private Env $env;
+    private bool $started = false;
+
+    public function __construct(Fs $fs, Env $env)
+    {
+        $this->fs = $fs;
+        $this->env = $env;
+    }
+
+    public function register(): void
+    {
+        if (!$this->isEnabled()) {
+            return;
+        }
+
+        add_action('template_redirect', [$this, 'maybeServeCache'], 0);
+        add_action('template_redirect', [$this, 'startBuffering'], PHP_INT_MAX);
+        add_action('shutdown', [$this, 'saveBuffer'], PHP_INT_MAX);
+    }
+
+    public function isEnabled(): bool
+    {
+        $settings = get_option(self::OPTION, ['enabled' => false]);
+        return !empty($settings['enabled']);
+    }
+
+    /**
+     * @return array{enabled:bool,ttl:int}
+     */
+    public function settings(): array
+    {
+        $defaults = [
+            'enabled' => false,
+            'ttl' => 3600,
+        ];
+        return wp_parse_args(get_option(self::OPTION, []), $defaults);
+    }
+
+    public function update(array $settings): void
+    {
+        update_option(self::OPTION, [
+            'enabled' => !empty($settings['enabled']),
+            'ttl' => isset($settings['ttl']) ? (int) $settings['ttl'] : 3600,
+        ]);
+    }
+
+    public function cacheDir(): string
+    {
+        $dir = WP_CONTENT_DIR . '/cache/fp-performance-suite';
+        if (!is_dir($dir)) {
+            wp_mkdir_p($dir);
+        }
+        return $dir;
+    }
+
+    public function clear(): void
+    {
+        $this->fs->delete($this->cacheDir());
+    }
+
+    public function maybeServeCache(): void
+    {
+        if (!$this->isCacheableRequest()) {
+            return;
+        }
+
+        $file = $this->cacheFile();
+        if (!file_exists($file)) {
+            return;
+        }
+
+        $meta = @json_decode((string) @file_get_contents($file . '.meta'), true);
+        $ttl = isset($meta['ttl']) ? (int) $meta['ttl'] : 3600;
+        if ($ttl > 0 && filemtime($file) + $ttl < time()) {
+            unlink($file);
+            @unlink($file . '.meta');
+            return;
+        }
+
+        $contents = file_get_contents($file);
+        if ($contents === false) {
+            return;
+        }
+
+        header('X-FP-Page-Cache: HIT');
+        echo $contents;
+        exit;
+    }
+
+    public function startBuffering(): void
+    {
+        if (!$this->isCacheableRequest()) {
+            return;
+        }
+
+        if ($this->started) {
+            return;
+        }
+
+        if (!ob_start([$this, 'maybeFilterOutput'])) {
+            ob_start();
+        }
+        $this->started = true;
+    }
+
+    public function maybeFilterOutput(string $buffer): string
+    {
+        return $buffer;
+    }
+
+    public function saveBuffer(): void
+    {
+        if (!$this->isCacheableRequest()) {
+            return;
+        }
+        if (headers_sent()) {
+            return;
+        }
+
+        $buffer = ob_get_contents();
+        if ($buffer === false || $buffer === '') {
+            return;
+        }
+
+        $file = $this->cacheFile();
+        $dir = dirname($file);
+        if (!is_dir($dir)) {
+            wp_mkdir_p($dir);
+        }
+
+        $this->fs->putContents($file, $buffer);
+        $this->fs->putContents($file . '.meta', wp_json_encode([
+            'ttl' => $this->settings()['ttl'],
+            'time' => time(),
+        ]));
+        $this->started = false;
+        if (ob_get_level() > 0) {
+            ob_end_flush();
+        }
+    }
+
+    private function isCacheableRequest(): bool
+    {
+        if (!$this->isEnabled()) {
+            return false;
+        }
+
+        if (!is_main_query() || is_user_logged_in() || is_admin() || defined('DONOTCACHEPAGE')) {
+            return false;
+        }
+
+        if (!in_array(strtoupper($_SERVER['REQUEST_METHOD'] ?? 'GET'), ['GET', 'HEAD'], true)) {
+            return false;
+        }
+
+        if (!empty($_GET)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private function cacheFile(): string
+    {
+        $host = sanitize_key(wp_parse_url(home_url(), PHP_URL_HOST) ?? 'site');
+        $path = trim(parse_url($_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH) ?? '/', '/');
+        $path = $path === '' ? 'index' : str_replace('/', '-', $path);
+        $dir = trailingslashit($this->cacheDir()) . $host;
+        wp_mkdir_p($dir);
+        return $dir . '/' . $path . '.html';
+    }
+
+    public function status(): array
+    {
+        $dir = $this->cacheDir();
+        $files = glob($dir . '/*.html');
+        $count = is_array($files) ? count($files) : 0;
+        return [
+            'enabled' => $this->isEnabled(),
+            'files' => $count,
+        ];
+    }
+}

--- a/fp-performance-suite/src/Services/DB/Cleaner.php
+++ b/fp-performance-suite/src/Services/DB/Cleaner.php
@@ -1,0 +1,274 @@
+<?php
+
+namespace FP\PerfSuite\Services\DB;
+
+use FP\PerfSuite\Utils\Env;
+use wpdb;
+use function __;
+use function add_action;
+use function add_filter;
+use function apply_filters;
+use function get_option;
+use function has_filter;
+use function sanitize_key;
+use function time;
+use function update_option;
+use function wp_clear_scheduled_hook;
+use function wp_next_scheduled;
+use function wp_schedule_event;
+
+class Cleaner
+{
+    private const OPTION = 'fp_ps_db';
+    public const CRON_HOOK = 'fp_ps_db_cleanup';
+    private Env $env;
+
+    public function __construct(Env $env)
+    {
+        $this->env = $env;
+    }
+
+    public function register(): void
+    {
+        $this->primeSchedules();
+        add_action(self::CRON_HOOK, [$this, 'runScheduledCleanup']);
+        add_action('update_option_' . self::OPTION, [$this, 'reschedule'], 10, 2);
+        $this->maybeSchedule();
+    }
+
+    public function primeSchedules(): void
+    {
+        if (!has_filter('cron_schedules', [$this, 'registerSchedules'])) {
+            add_filter('cron_schedules', [$this, 'registerSchedules']);
+        }
+    }
+
+    /**
+     * @return array{schedule:string,batch:int}
+     */
+    public function settings(): array
+    {
+        $defaults = [
+            'schedule' => 'manual',
+            'batch' => 200,
+        ];
+        return wp_parse_args(get_option(self::OPTION, []), $defaults);
+    }
+
+    public function update(array $settings): void
+    {
+        $current = $this->settings();
+        $new = [
+            'schedule' => sanitize_key($settings['schedule'] ?? $current['schedule']),
+            'batch' => isset($settings['batch']) ? max(50, (int) $settings['batch']) : $current['batch'],
+        ];
+        update_option(self::OPTION, $new);
+    }
+
+    /**
+     * @param array $schedules
+     * @return array
+     */
+    public function registerSchedules(array $schedules): array
+    {
+        $schedules['fp_ps_weekly'] = [
+            'interval' => WEEK_IN_SECONDS,
+            'display' => __('Once Weekly (FP Performance Suite)', 'fp-performance-suite'),
+        ];
+        $schedules['fp_ps_monthly'] = [
+            'interval' => 30 * DAY_IN_SECONDS,
+            'display' => __('Once Monthly (FP Performance Suite)', 'fp-performance-suite'),
+        ];
+        return $schedules;
+    }
+
+    /**
+     * @param mixed $old
+     * @param mixed $value
+     */
+    public function reschedule($old, $value): void
+    {
+        $this->maybeSchedule(true);
+    }
+
+    public function maybeSchedule(bool $force = false): void
+    {
+        if ($force) {
+            wp_clear_scheduled_hook(self::CRON_HOOK);
+        }
+
+        $settings = $this->settings();
+        if (($settings['schedule'] ?? 'manual') === 'manual') {
+            wp_clear_scheduled_hook(self::CRON_HOOK);
+            return;
+        }
+
+        $recurrence = $settings['schedule'] === 'monthly' ? 'fp_ps_monthly' : 'fp_ps_weekly';
+        if (!wp_next_scheduled(self::CRON_HOOK)) {
+            wp_schedule_event(time() + HOUR_IN_SECONDS, $recurrence, self::CRON_HOOK);
+        }
+    }
+
+    public function runScheduledCleanup(): void
+    {
+        $scope = apply_filters('fp_ps_db_scheduled_scope', [
+            'revisions',
+            'auto_drafts',
+            'trash_posts',
+            'spam_comments',
+            'expired_transients',
+        ]);
+        $results = $this->cleanup($scope, false, $this->settings()['batch']);
+        update_option('fp_ps_db_last_report', [
+            'time' => time(),
+            'scope' => $scope,
+            'results' => $results,
+        ]);
+    }
+
+    /**
+     * @param array<int,string> $scope
+     * @return array<string, mixed>
+     */
+    public function cleanup(array $scope, bool $dryRun = true, ?int $batch = null): array
+    {
+        global $wpdb;
+        $batch = $batch ?: $this->settings()['batch'];
+        $results = [];
+
+        foreach ($scope as $task) {
+            switch ($task) {
+                case 'revisions':
+                    $results['revisions'] = $this->cleanupPosts($wpdb, "post_type = 'revision'", $dryRun, $batch);
+                    break;
+                case 'auto_drafts':
+                    $results['auto_drafts'] = $this->cleanupPosts($wpdb, "post_status = 'auto-draft'", $dryRun, $batch);
+                    break;
+                case 'trash_posts':
+                    $results['trash_posts'] = $this->cleanupPosts($wpdb, "post_status = 'trash'", $dryRun, $batch);
+                    break;
+                case 'spam_comments':
+                    $results['spam_comments'] = $this->cleanupComments($wpdb, ["comment_approved = 'spam'", "comment_approved = 'trash'"] , $dryRun, $batch);
+                    break;
+                case 'expired_transients':
+                    $results['expired_transients'] = $this->cleanupTransients($wpdb, $dryRun, $batch);
+                    break;
+                case 'orphan_postmeta':
+                    $results['orphan_postmeta'] = $this->cleanupMeta($wpdb, $wpdb->postmeta, $wpdb->posts, 'post_id', 'ID', $dryRun, $batch);
+                    break;
+                case 'orphan_termmeta':
+                    $results['orphan_termmeta'] = $this->cleanupMeta($wpdb, $wpdb->termmeta, $wpdb->terms, 'term_id', 'term_id', $dryRun, $batch);
+                    break;
+                case 'orphan_usermeta':
+                    $results['orphan_usermeta'] = $this->cleanupMeta($wpdb, $wpdb->usermeta, $wpdb->users, 'user_id', 'ID', $dryRun, $batch);
+                    break;
+                case 'optimize_tables':
+                    $results['optimize_tables'] = $this->optimizeTables($wpdb, $dryRun);
+                    break;
+            }
+        }
+
+        return $results;
+    }
+
+    /**
+     * @return array<string,int>
+     */
+    private function cleanupPosts(wpdb $wpdb, string $where, bool $dryRun, int $batch): array
+    {
+        $table = $wpdb->posts;
+        $sql = $wpdb->prepare("SELECT ID FROM {$table} WHERE {$where} LIMIT %d", $batch);
+        $ids = $wpdb->get_col($sql);
+        $count = count($ids);
+        if (!$dryRun && $count > 0) {
+            $placeholders = implode(',', array_fill(0, $count, '%d'));
+            $wpdb->query($wpdb->prepare("DELETE FROM {$table} WHERE ID IN ({$placeholders})", $ids));
+        }
+        return ['found' => $count, 'deleted' => $dryRun ? 0 : $count];
+    }
+
+    /**
+     * @param array<int,string> $statuses
+     * @return array<string,int>
+     */
+    private function cleanupComments(wpdb $wpdb, array $statuses, bool $dryRun, int $batch): array
+    {
+        $table = $wpdb->comments;
+        $placeholders = implode(',', array_fill(0, count($statuses), '%s'));
+        $params = array_merge($statuses, [$batch]);
+        $query = $wpdb->prepare("SELECT comment_ID FROM {$table} WHERE comment_approved IN ({$placeholders}) LIMIT %d", $params);
+        $ids = $wpdb->get_col($query);
+        $count = count($ids);
+        if (!$dryRun && $count > 0) {
+            $placeholders = implode(',', array_fill(0, $count, '%d'));
+            $wpdb->query($wpdb->prepare("DELETE FROM {$table} WHERE comment_ID IN ({$placeholders})", $ids));
+        }
+        return ['found' => $count, 'deleted' => $dryRun ? 0 : $count];
+    }
+
+    private function cleanupTransients(wpdb $wpdb, bool $dryRun, int $batch): array
+    {
+        $time = time();
+        $sql = $wpdb->prepare("SELECT option_name FROM {$wpdb->options} WHERE option_name LIKE %s AND option_value < %d LIMIT %d", '_transient_timeout_%', $time, $batch);
+        $names = $wpdb->get_col($sql);
+        $count = count($names);
+        if (!$dryRun && $count > 0) {
+            foreach ($names as $name) {
+                $key = str_replace('_transient_timeout_', '', $name);
+                delete_transient($key);
+            }
+        }
+        return ['found' => $count, 'deleted' => $dryRun ? 0 : $count];
+    }
+
+    private function cleanupMeta(wpdb $wpdb, string $metaTable, string $parentTable, string $foreignKey, string $parentKey, bool $dryRun, int $batch): array
+    {
+        $sql = $wpdb->prepare("SELECT m.meta_id FROM {$metaTable} m LEFT JOIN {$parentTable} p ON m.{$foreignKey} = p.{$parentKey} WHERE p.{$parentKey} IS NULL LIMIT %d", $batch);
+        $ids = $wpdb->get_col($sql);
+        $count = count($ids);
+        if (!$dryRun && $count > 0) {
+            $placeholders = implode(',', array_fill(0, $count, '%d'));
+            $wpdb->query($wpdb->prepare("DELETE FROM {$metaTable} WHERE meta_id IN ({$placeholders})", $ids));
+        }
+        return ['found' => $count, 'deleted' => $dryRun ? 0 : $count];
+    }
+
+    private function optimizeTables(wpdb $wpdb, bool $dryRun): array
+    {
+        $tables = $wpdb->get_col('SHOW TABLES');
+        $run = [];
+        foreach ($tables as $table) {
+            if ($dryRun) {
+                $run[] = $table;
+                continue;
+            }
+            $wpdb->query("OPTIMIZE TABLE {$table}");
+            $run[] = $table;
+        }
+        return ['tables' => $run];
+    }
+
+    public function overhead(): float
+    {
+        global $wpdb;
+        $status = $wpdb->get_results('SHOW TABLE STATUS');
+        $overhead = 0.0;
+        foreach ($status as $row) {
+            if (!empty($row->Data_free)) {
+                $overhead += (float) $row->Data_free;
+            }
+        }
+        return $overhead / 1024 / 1024; // MB
+    }
+
+    public function status(): array
+    {
+        $report = get_option('fp_ps_db_last_report', []);
+        return [
+            'overhead_mb' => round($this->overhead(), 2),
+            'schedule' => $this->settings()['schedule'],
+            'last_run' => isset($report['time']) ? (int) $report['time'] : 0,
+            'last_scope' => $report['scope'] ?? [],
+        ];
+    }
+}

--- a/fp-performance-suite/src/Services/Logs/DebugToggler.php
+++ b/fp-performance-suite/src/Services/Logs/DebugToggler.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace FP\PerfSuite\Services\Logs;
+
+use FP\PerfSuite\Utils\Fs;
+use FP\PerfSuite\Utils\Env;
+
+class DebugToggler
+{
+    private Fs $fs;
+    private Env $env;
+
+    public function __construct(Fs $fs, Env $env)
+    {
+        $this->fs = $fs;
+        $this->env = $env;
+    }
+
+    public function status(): array
+    {
+        return [
+            'WP_DEBUG' => defined('WP_DEBUG') ? (bool) WP_DEBUG : false,
+            'WP_DEBUG_LOG' => defined('WP_DEBUG_LOG') ? (bool) WP_DEBUG_LOG : false,
+            'log_file' => defined('WP_DEBUG_LOG') && WP_DEBUG_LOG ? WP_CONTENT_DIR . '/debug.log' : '',
+        ];
+    }
+
+    public function toggle(bool $enabled, bool $log = true): bool
+    {
+        $config = ABSPATH . 'wp-config.php';
+        if (!$this->fs->exists($config)) {
+            return false;
+        }
+
+        $original = $this->fs->getContents($config);
+        $this->backup($config, $original);
+
+        $replacements = [
+            "define('WP_DEBUG', true);" => "define('WP_DEBUG', " . ($enabled ? 'true' : 'false') . ");",
+            "define('WP_DEBUG_LOG', true);" => "define('WP_DEBUG_LOG', " . ($log ? 'true' : 'false') . ");",
+        ];
+
+        $updated = $original;
+        foreach ($replacements as $needle => $replacement) {
+            $count = 0;
+            if (strpos($updated, $needle) !== false) {
+                $updated = str_replace($needle, $replacement, $updated);
+            } else {
+                $updated = preg_replace("/define\('(WP_DEBUG|WP_DEBUG_LOG)',\s*(true|false)\);/", $replacement, $updated, 1, $count);
+                if ($count === 0) {
+                    $updated = preg_replace('/(<\?php)/', "$1\n{$replacement}", $updated, 1);
+                }
+            }
+        }
+
+        return $this->fs->putContents($config, $updated);
+    }
+
+    public function backup(string $config, string $contents): void
+    {
+        $backupFile = $config . '.fp-backup-' . gmdate('YmdHis');
+        $this->fs->putContents($backupFile, $contents);
+    }
+
+    public function revertLatest(): bool
+    {
+        $config = ABSPATH . 'wp-config.php';
+        $pattern = $config . '.fp-backup-*';
+        $backups = glob($pattern);
+        if (empty($backups)) {
+            return false;
+        }
+        rsort($backups);
+        $latest = $backups[0];
+        $contents = $this->fs->getContents($latest);
+        $this->fs->putContents($config, $contents);
+        return true;
+    }
+}

--- a/fp-performance-suite/src/Services/Logs/RealtimeLog.php
+++ b/fp-performance-suite/src/Services/Logs/RealtimeLog.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace FP\PerfSuite\Services\Logs;
+
+class RealtimeLog
+{
+    private DebugToggler $toggler;
+
+    public function __construct(DebugToggler $toggler)
+    {
+        $this->toggler = $toggler;
+    }
+
+    public function tail(int $lines = 200, string $level = '', string $query = ''): array
+    {
+        $status = $this->toggler->status();
+        $file = $status['log_file'];
+        if (empty($file) || !file_exists($file)) {
+            return [];
+        }
+        $content = $this->readTail($file, $lines);
+        $rows = explode("\n", trim($content));
+        $filtered = array_filter($rows, static function ($row) use ($level, $query) {
+            $match = true;
+            if ($level) {
+                $match = stripos($row, $level) !== false;
+            }
+            if ($match && $query) {
+                $match = stripos($row, $query) !== false;
+            }
+            return $match;
+        });
+        return array_values($filtered);
+    }
+
+    private function readTail(string $file, int $lines): string
+    {
+        $handle = fopen($file, 'rb');
+        if (!$handle) {
+            return '';
+        }
+        $buffer = '';
+        $chunk = 4096;
+        fseek($handle, 0, SEEK_END);
+        $position = ftell($handle);
+        while ($position > 0 && $lines > 0) {
+            $seek = max($position - $chunk, 0);
+            $read = $position - $seek;
+            fseek($handle, $seek);
+            $buffer = fread($handle, $read) . $buffer;
+            $position = $seek;
+            $lines -= substr_count($buffer, "\n");
+        }
+        fclose($handle);
+        $parts = explode("\n", trim($buffer));
+        return implode("\n", array_slice($parts, -$lines));
+    }
+}

--- a/fp-performance-suite/src/Services/Media/WebPConverter.php
+++ b/fp-performance-suite/src/Services/Media/WebPConverter.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace FP\PerfSuite\Services\Media;
+
+use FP\PerfSuite\Utils\Fs;
+use WP_Query;
+
+class WebPConverter
+{
+    private const OPTION = 'fp_ps_webp';
+    private Fs $fs;
+
+    public function __construct(Fs $fs)
+    {
+        $this->fs = $fs;
+    }
+
+    public function register(): void
+    {
+        if (!$this->settings()['enabled']) {
+            return;
+        }
+
+        add_filter('wp_generate_attachment_metadata', [$this, 'generateWebp'], 10, 2);
+        add_filter('wp_update_attachment_metadata', [$this, 'generateWebp'], 10, 2);
+    }
+
+    /**
+     * @return array{enabled:bool,quality:int,keep_original:bool,lossy:bool}
+     */
+    public function settings(): array
+    {
+        $defaults = [
+            'enabled' => false,
+            'quality' => 82,
+            'keep_original' => true,
+            'lossy' => true,
+        ];
+        return wp_parse_args(get_option(self::OPTION, []), $defaults);
+    }
+
+    public function update(array $settings): void
+    {
+        $current = $this->settings();
+        $new = [
+            'enabled' => !empty($settings['enabled']),
+            'quality' => isset($settings['quality']) ? (int) $settings['quality'] : $current['quality'],
+            'keep_original' => !empty($settings['keep_original']),
+            'lossy' => !empty($settings['lossy']),
+        ];
+        update_option(self::OPTION, $new);
+    }
+
+    /**
+     * @param array<string, mixed> $metadata
+     * @param int $attachment_id
+     * @return array<string, mixed>
+     */
+    public function generateWebp(array $metadata, int $attachment_id): array
+    {
+        $settings = $this->settings();
+        if (!$settings['enabled']) {
+            return $metadata;
+        }
+
+        $file = get_attached_file($attachment_id);
+        if (!$file || !file_exists($file)) {
+            return $metadata;
+        }
+
+        $this->convert($file, $settings);
+        if (!empty($metadata['sizes'])) {
+            foreach ($metadata['sizes'] as $size) {
+                if (!empty($size['file'])) {
+                    $path = path_join(dirname($file), $size['file']);
+                    $this->convert($path, $settings);
+                }
+            }
+        }
+        return $metadata;
+    }
+
+    /**
+     * @param string $file
+     * @param array<string, mixed> $settings
+     */
+    public function convert(string $file, array $settings): void
+    {
+        $info = pathinfo($file);
+        $ext = strtolower($info['extension'] ?? '');
+        if (!in_array($ext, ['jpg', 'jpeg', 'png'], true)) {
+            return;
+        }
+
+        $webpFile = $info['dirname'] . '/' . $info['filename'] . '.webp';
+        if (file_exists($webpFile)) {
+            return;
+        }
+
+        if (class_exists('Imagick')) {
+            $imagick = new \Imagick($file);
+            if ($settings['lossy']) {
+                $imagick->setImageCompressionQuality($settings['quality']);
+            }
+            $imagick->setImageFormat('webp');
+            $imagick->writeImage($webpFile);
+            $imagick->clear();
+            $imagick->destroy();
+        } elseif (function_exists('imagecreatefromstring') && function_exists('imagewebp')) {
+            $image = imagecreatefromstring((string) file_get_contents($file));
+            if ($image !== false) {
+                imagepalettetotruecolor($image);
+                imagewebp($image, $webpFile, $settings['quality']);
+                imagedestroy($image);
+            }
+        }
+
+        if (!$settings['keep_original'] && file_exists($webpFile)) {
+            unlink($file);
+        }
+    }
+
+    public function bulkConvert(int $limit = 20, int $offset = 0): array
+    {
+        $query = new WP_Query([
+            'post_type' => 'attachment',
+            'post_status' => 'inherit',
+            'post_mime_type' => ['image/jpeg', 'image/png'],
+            'posts_per_page' => $limit,
+            'offset' => $offset,
+            'fields' => 'ids',
+        ]);
+        $settings = $this->settings();
+        $converted = 0;
+
+        foreach ($query->posts as $attachment_id) {
+            $metadata = wp_get_attachment_metadata($attachment_id);
+            $this->generateWebp($metadata ?: [], (int) $attachment_id);
+            $converted++;
+        }
+
+        return [
+            'converted' => $converted,
+            'total' => (int) $query->found_posts,
+        ];
+    }
+
+    public function coverage(): float
+    {
+        $count = (int) wp_count_attachments('image')['inherit'] ?? 0;
+        if ($count === 0) {
+            return 100.0;
+        }
+        global $wpdb;
+        $like = $wpdb->esc_like('.webp');
+        $webp = (int) $wpdb->get_var("SELECT COUNT(*) FROM {$wpdb->postmeta} WHERE meta_key = '_wp_attached_file' AND meta_value LIKE '%$like'");
+        return min(100.0, ($webp / $count) * 100);
+    }
+
+    public function status(): array
+    {
+        $settings = $this->settings();
+        return [
+            'enabled' => $settings['enabled'],
+            'quality' => $settings['quality'],
+            'coverage' => $this->coverage(),
+        ];
+    }
+}

--- a/fp-performance-suite/src/Services/Presets/Manager.php
+++ b/fp-performance-suite/src/Services/Presets/Manager.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace FP\PerfSuite\Services\Presets;
+
+use FP\PerfSuite\Services\Assets\Optimizer;
+use FP\PerfSuite\Services\Cache\Headers;
+use FP\PerfSuite\Services\Cache\PageCache;
+use FP\PerfSuite\Services\DB\Cleaner;
+use FP\PerfSuite\Services\Logs\DebugToggler;
+use FP\PerfSuite\Services\Media\WebPConverter;
+use function __;
+
+class Manager
+{
+    private const OPTION = 'fp_ps_preset';
+
+    private PageCache $pageCache;
+    private Headers $headers;
+    private Optimizer $optimizer;
+    private WebPConverter $webp;
+    private Cleaner $cleaner;
+    private DebugToggler $debugToggler;
+
+    public function __construct(PageCache $pageCache, Headers $headers, Optimizer $optimizer, WebPConverter $webp, Cleaner $cleaner, DebugToggler $debugToggler)
+    {
+        $this->pageCache = $pageCache;
+        $this->headers = $headers;
+        $this->optimizer = $optimizer;
+        $this->webp = $webp;
+        $this->cleaner = $cleaner;
+        $this->debugToggler = $debugToggler;
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    public function presets(): array
+    {
+        return [
+            'generale' => [
+                'label' => __('Generale', 'fp-performance-suite'),
+                'config' => [
+                    'page_cache' => ['enabled' => true, 'ttl' => 3600],
+                    'browser_cache' => ['enabled' => true],
+                    'assets' => ['minify_html' => true, 'defer_js' => true, 'combine_css' => false, 'combine_js' => false],
+                    'webp' => ['enabled' => true, 'quality' => 75, 'lossy' => true],
+                    'db' => ['batch' => 200],
+                    'heartbeat' => 60,
+                ],
+            ],
+            'ionos' => [
+                'label' => __('IONOS', 'fp-performance-suite'),
+                'config' => [
+                    'page_cache' => ['enabled' => true, 'ttl' => 1800],
+                    'browser_cache' => ['enabled' => false],
+                    'assets' => ['minify_html' => true, 'defer_js' => true, 'combine_css' => false, 'combine_js' => false, 'async_js' => false],
+                    'webp' => ['enabled' => true, 'quality' => 80],
+                    'db' => ['batch' => 150],
+                    'heartbeat' => 80,
+                ],
+            ],
+            'aruba' => [
+                'label' => __('Aruba', 'fp-performance-suite'),
+                'config' => [
+                    'page_cache' => ['enabled' => true, 'ttl' => 900],
+                    'browser_cache' => ['enabled' => true],
+                    'assets' => ['minify_html' => true, 'defer_js' => true, 'combine_css' => false, 'combine_js' => false, 'preload' => []],
+                    'webp' => ['enabled' => true, 'quality' => 70],
+                    'db' => ['batch' => 100],
+                    'heartbeat' => 90,
+                ],
+            ],
+        ];
+    }
+
+    public function apply(string $id): array
+    {
+        $preset = $this->presets()[$id] ?? null;
+        if (!$preset) {
+            return ['error' => __('Preset not found', 'fp-performance-suite')];
+        }
+
+        $config = $preset['config'];
+        $previous = [
+            'page_cache' => $this->pageCache->settings(),
+            'browser_cache' => $this->headers->settings(),
+            'assets' => $this->optimizer->settings(),
+            'webp' => $this->webp->settings(),
+            'db' => $this->cleaner->settings(),
+        ];
+        $this->pageCache->update($config['page_cache']);
+        $this->headers->update(array_merge($this->headers->settings(), ['enabled' => !empty($config['browser_cache']['enabled'])]));
+        $this->optimizer->update(array_merge($this->optimizer->settings(), $config['assets']));
+        $this->webp->update(array_merge($this->webp->settings(), $config['webp']));
+        $this->cleaner->update(array_merge($this->cleaner->settings(), $config['db']));
+        $this->optimizer->update(array_merge($this->optimizer->settings(), ['heartbeat_admin' => $config['heartbeat']]));
+
+        update_option(self::OPTION, [
+            'active' => $id,
+            'applied_at' => time(),
+            'previous' => $previous,
+        ]);
+        return ['success' => true];
+    }
+
+    public function rollback(): bool
+    {
+        $option = get_option(self::OPTION, []);
+        if (empty($option['previous'])) {
+            return false;
+        }
+        $prev = $option['previous'];
+        $this->pageCache->update($prev['page_cache']);
+        $this->headers->update($prev['browser_cache']);
+        $this->optimizer->update($prev['assets']);
+        $this->webp->update($prev['webp']);
+        $this->cleaner->update($prev['db']);
+        update_option(self::OPTION, ['active' => null, 'applied_at' => time(), 'previous' => []]);
+        return true;
+    }
+
+    public function getActivePreset(): ?string
+    {
+        $option = get_option(self::OPTION, []);
+        return $option['active'] ?? null;
+    }
+
+    public function labelFor(string $id): string
+    {
+        $presets = $this->presets();
+        return $presets[$id]['label'] ?? ucfirst($id);
+    }
+}

--- a/fp-performance-suite/src/Services/Score/Scorer.php
+++ b/fp-performance-suite/src/Services/Score/Scorer.php
@@ -1,0 +1,261 @@
+<?php
+
+namespace FP\PerfSuite\Services\Score;
+
+use FP\PerfSuite\Services\Assets\Optimizer;
+use FP\PerfSuite\Services\Cache\Headers;
+use FP\PerfSuite\Services\Cache\PageCache;
+use FP\PerfSuite\Services\DB\Cleaner;
+use FP\PerfSuite\Services\Logs\DebugToggler;
+use FP\PerfSuite\Services\Media\WebPConverter;
+use function __;
+
+class Scorer
+{
+    private PageCache $pageCache;
+    private Headers $headers;
+    private Optimizer $optimizer;
+    private WebPConverter $webp;
+    private Cleaner $cleaner;
+    private DebugToggler $debugToggler;
+
+    public function __construct(PageCache $pageCache, Headers $headers, Optimizer $optimizer, WebPConverter $webp, Cleaner $cleaner, DebugToggler $debugToggler)
+    {
+        $this->pageCache = $pageCache;
+        $this->headers = $headers;
+        $this->optimizer = $optimizer;
+        $this->webp = $webp;
+        $this->cleaner = $cleaner;
+        $this->debugToggler = $debugToggler;
+    }
+
+    /**
+     * @return array{total:int,breakdown:array<string,int>,suggestions:array<int,string>}
+     */
+    public function calculate(): array
+    {
+        $score = 0;
+        $breakdown = [];
+        $suggestions = [];
+
+        [$points, $suggestion] = $this->gzipScore();
+        $score += $points;
+        $breakdown[__('GZIP/Brotli', 'fp-performance-suite')] = $points;
+        if ($suggestion) {
+            $suggestions[] = $suggestion;
+        }
+
+        [$points, $suggestion] = $this->browserCacheScore();
+        $score += $points;
+        $breakdown[__('Browser cache headers', 'fp-performance-suite')] = $points;
+        if ($suggestion) {
+            $suggestions[] = $suggestion;
+        }
+
+        [$points, $suggestion] = $this->pageCacheScore();
+        $score += $points;
+        $breakdown[__('Page cache', 'fp-performance-suite')] = $points;
+        if ($suggestion) {
+            $suggestions[] = $suggestion;
+        }
+
+        [$points, $suggestion] = $this->assetsScore();
+        $score += $points;
+        $breakdown[__('Asset optimization', 'fp-performance-suite')] = $points;
+        if ($suggestion) {
+            $suggestions[] = $suggestion;
+        }
+
+        [$points, $suggestion] = $this->webpScore();
+        $score += $points;
+        $breakdown[__('WebP coverage', 'fp-performance-suite')] = $points;
+        if ($suggestion) {
+            $suggestions[] = $suggestion;
+        }
+
+        [$points, $suggestion] = $this->databaseScore();
+        $score += $points;
+        $breakdown[__('Database health', 'fp-performance-suite')] = $points;
+        if ($suggestion) {
+            $suggestions[] = $suggestion;
+        }
+
+        [$points, $suggestion] = $this->heartbeatScore();
+        $score += $points;
+        $breakdown[__('Heartbeat throttling', 'fp-performance-suite')] = $points;
+        if ($suggestion) {
+            $suggestions[] = $suggestion;
+        }
+
+        [$points, $suggestion] = $this->emojiScore();
+        $score += $points;
+        $breakdown[__('Emoji & embeds', 'fp-performance-suite')] = $points;
+        if ($suggestion) {
+            $suggestions[] = $suggestion;
+        }
+
+        [$points, $suggestion] = $this->criticalCssScore();
+        $score += $points;
+        $breakdown[__('Critical CSS', 'fp-performance-suite')] = $points;
+        if ($suggestion) {
+            $suggestions[] = $suggestion;
+        }
+
+        [$points, $suggestion] = $this->logScore();
+        $score += $points;
+        $breakdown[__('Logs hygiene', 'fp-performance-suite')] = $points;
+        if ($suggestion) {
+            $suggestions[] = $suggestion;
+        }
+
+        return [
+            'total' => min(100, $score),
+            'breakdown' => $breakdown,
+            'suggestions' => $suggestions,
+        ];
+    }
+
+    public function activeOptimizations(): array
+    {
+        $active = [];
+        if ($this->pageCache->isEnabled()) {
+            $active[] = __('Page caching enabled', 'fp-performance-suite');
+        }
+        $headerStatus = $this->headers->status();
+        if (!empty($headerStatus['enabled'])) {
+            $active[] = __('Browser cache headers applied', 'fp-performance-suite');
+        }
+        $assetStatus = $this->optimizer->status();
+        if (!empty($assetStatus['defer_js'])) {
+            $active[] = __('Defer JS active', 'fp-performance-suite');
+        }
+        if (!empty($assetStatus['remove_emojis'])) {
+            $active[] = __('Emoji scripts removed', 'fp-performance-suite');
+        }
+        $webpStatus = $this->webp->status();
+        if (!empty($webpStatus['enabled'])) {
+            $active[] = __('WebP conversion enabled', 'fp-performance-suite');
+        }
+        return $active;
+    }
+
+    private function gzipScore(): array
+    {
+        $enabled = (bool) ini_get('zlib.output_compression') || function_exists('ob_gzhandler');
+        if ($enabled) {
+            return [10, null];
+        }
+        return [0, __('Enable GZIP or Brotli compression via server configuration.', 'fp-performance-suite')];
+    }
+
+    private function browserCacheScore(): array
+    {
+        $status = $this->headers->status();
+        if (!empty($status['enabled'])) {
+            return [10, null];
+        }
+        return [2, __('Activate browser caching headers for static assets.', 'fp-performance-suite')];
+    }
+
+    private function pageCacheScore(): array
+    {
+        if ($this->pageCache->isEnabled()) {
+            return [15, null];
+        }
+        return [5, __('Enable page caching to store HTML output on disk.', 'fp-performance-suite')];
+    }
+
+    private function assetsScore(): array
+    {
+        $status = $this->optimizer->status();
+        $points = 0;
+        $suggestions = [];
+        if (!empty($status['minify_html'])) {
+            $points += 5;
+        } else {
+            $suggestions[] = __('Enable HTML/CSS minification to reduce payload.', 'fp-performance-suite');
+        }
+        if (!empty($status['defer_js'])) {
+            $points += 5;
+        } else {
+            $suggestions[] = __('Consider deferring non-critical JavaScript.', 'fp-performance-suite');
+        }
+        return [$points, implode(' ', $suggestions) ?: null];
+    }
+
+    private function webpScore(): array
+    {
+        $status = $this->webp->status();
+        $coverage = $status['coverage'];
+        if ($coverage >= 80) {
+            return [15, null];
+        }
+        if ($coverage >= 40) {
+            return [8, __('Run bulk WebP conversion to improve coverage.', 'fp-performance-suite')];
+        }
+        return [3, __('Enable WebP conversion to serve modern formats.', 'fp-performance-suite')];
+    }
+
+    private function databaseScore(): array
+    {
+        $overhead = $this->cleaner->status()['overhead_mb'];
+        if ($overhead < 5) {
+            return [10, null];
+        }
+        if ($overhead < 20) {
+            return [6, __('Schedule routine database cleanup to reduce overhead.', 'fp-performance-suite')];
+        }
+        return [2, __('Run database optimization to reclaim space.', 'fp-performance-suite')];
+    }
+
+    private function heartbeatScore(): array
+    {
+        $status = $this->optimizer->status();
+        $interval = (int) $status['heartbeat_admin'];
+        if ($interval >= 60) {
+            return [5, null];
+        }
+        if ($interval >= 40) {
+            return [3, __('Increase admin heartbeat interval to reduce CPU load.', 'fp-performance-suite')];
+        }
+        return [1, __('Throttle heartbeat on shared hosting to 60 seconds.', 'fp-performance-suite')];
+    }
+
+    private function emojiScore(): array
+    {
+        $status = $this->optimizer->status();
+        $removed = !empty($status['remove_emojis']);
+        $embedsDisabled = !has_action('wp_head', 'wp_oembed_add_discovery_links');
+        if ($removed && $embedsDisabled) {
+            return [5, null];
+        }
+        return [2, __('Disable emojis and embeds to reduce front-end requests.', 'fp-performance-suite')];
+    }
+
+    private function criticalCssScore(): array
+    {
+        $critical = get_option('fp_ps_critical_css', '');
+        if (!empty($critical)) {
+            return [5, null];
+        }
+        return [0, __('Add critical CSS placeholder for above-the-fold styles.', 'fp-performance-suite')];
+    }
+
+    private function logScore(): array
+    {
+        $status = $this->debugToggler->status();
+        $file = $status['log_file'];
+        if (!$file || !file_exists($file)) {
+            return [15, null];
+        }
+        $mtime = filemtime($file);
+        if ($mtime && $mtime < strtotime('-1 day')) {
+            return [15, null];
+        }
+        $size = filesize($file);
+        if ($size < 10240) {
+            return [12, __('Review debug log for warnings in the last 24 hours.', 'fp-performance-suite')];
+        }
+        return [6, __('Log file is noisy. Resolve errors and clear debug.log.', 'fp-performance-suite')];
+    }
+}

--- a/fp-performance-suite/src/Utils/Env.php
+++ b/fp-performance-suite/src/Utils/Env.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace FP\PerfSuite\Utils;
+
+class Env
+{
+    public function isMultisite(): bool
+    {
+        return function_exists('is_multisite') && is_multisite();
+    }
+
+    public function isCli(): bool
+    {
+        return defined('WP_CLI') && WP_CLI;
+    }
+
+    public function serverSoftware(): string
+    {
+        return $_SERVER['SERVER_SOFTWARE'] ?? '';
+    }
+
+    public function isApache(): bool
+    {
+        return stripos($this->serverSoftware(), 'Apache') !== false;
+    }
+}

--- a/fp-performance-suite/src/Utils/Fs.php
+++ b/fp-performance-suite/src/Utils/Fs.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace FP\PerfSuite\Utils;
+
+use WP_Filesystem_Base;
+
+class Fs
+{
+    private ?WP_Filesystem_Base $fs = null;
+
+    private function ensure(): WP_Filesystem_Base
+    {
+        global $wp_filesystem;
+        if ($this->fs instanceof WP_Filesystem_Base) {
+            return $this->fs;
+        }
+
+        if (!function_exists('WP_Filesystem')) {
+            require_once ABSPATH . 'wp-admin/includes/file.php';
+        }
+
+        WP_Filesystem();
+        $this->fs = $wp_filesystem;
+
+        return $this->fs;
+    }
+
+    public function putContents(string $file, string $contents): bool
+    {
+        $fs = $this->ensure();
+        return $fs->put_contents($file, $contents, FS_CHMOD_FILE);
+    }
+
+    public function getContents(string $file): string
+    {
+        $fs = $this->ensure();
+        return (string) $fs->get_contents($file);
+    }
+
+    public function exists(string $file): bool
+    {
+        $fs = $this->ensure();
+        return $fs->exists($file);
+    }
+
+    public function mkdir(string $path): bool
+    {
+        $fs = $this->ensure();
+        return $fs->mkdir($path, FS_CHMOD_DIR);
+    }
+
+    public function delete(string $path): bool
+    {
+        $fs = $this->ensure();
+        return $fs->delete($path, true);
+    }
+
+    public function copy(string $source, string $destination, bool $overwrite = true): bool
+    {
+        $fs = $this->ensure();
+        return $fs->copy($source, $destination, $overwrite, FS_CHMOD_FILE);
+    }
+}

--- a/fp-performance-suite/src/Utils/Htaccess.php
+++ b/fp-performance-suite/src/Utils/Htaccess.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace FP\PerfSuite\Utils;
+
+class Htaccess
+{
+    private Fs $fs;
+
+    public function __construct(Fs $fs)
+    {
+        $this->fs = $fs;
+    }
+
+    public function isSupported(): bool
+    {
+        return function_exists('got_mod_rewrite') && got_mod_rewrite() && is_writable(ABSPATH . '.htaccess');
+    }
+
+    public function backup(string $file): ?string
+    {
+        if (!$this->fs->exists($file)) {
+            return null;
+        }
+        $backup = $file . '.bak-' . gmdate('YmdHis');
+        $this->fs->copy($file, $backup, true);
+        return $backup;
+    }
+
+    public function injectRules(string $section, string $rules): bool
+    {
+        $file = ABSPATH . '.htaccess';
+        $existing = $this->fs->exists($file) ? $this->fs->getContents($file) : '';
+        $markerStart = "# BEGIN {$section}";
+        $markerEnd = "# END {$section}";
+
+        $pattern = sprintf('/%s.*?%s/s', preg_quote($markerStart, '/'), preg_quote($markerEnd, '/'));
+        $block = $markerStart . PHP_EOL . trim($rules) . PHP_EOL . $markerEnd;
+
+        if (preg_match($pattern, $existing)) {
+            $updated = preg_replace($pattern, $block, $existing);
+        } else {
+            $updated = $existing . PHP_EOL . $block . PHP_EOL;
+        }
+
+        $this->backup($file);
+        return $this->fs->putContents($file, (string) $updated);
+    }
+
+    public function removeSection(string $section): bool
+    {
+        $file = ABSPATH . '.htaccess';
+        if (!$this->fs->exists($file)) {
+            return false;
+        }
+        $existing = $this->fs->getContents($file);
+        $markerStart = "# BEGIN {$section}";
+        $markerEnd = "# END {$section}";
+        $pattern = sprintf('/%s.*?%s\n?/s', preg_quote($markerStart, '/'), preg_quote($markerEnd, '/'));
+        $updated = preg_replace($pattern, '', $existing);
+        $this->backup($file);
+        return $this->fs->putContents($file, (string) $updated);
+    }
+}

--- a/fp-performance-suite/src/Utils/Semaphore.php
+++ b/fp-performance-suite/src/Utils/Semaphore.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace FP\PerfSuite\Utils;
+
+class Semaphore
+{
+    /**
+     * @param string $key
+     * @param string $color
+     * @param string $description
+     * @return array<string, string>
+     */
+    public function describe(string $key, string $color, string $description): array
+    {
+        return [
+            'key' => $key,
+            'color' => $color,
+            'description' => $description,
+        ];
+    }
+}

--- a/fp-performance-suite/tests/CleanerTest.php
+++ b/fp-performance-suite/tests/CleanerTest.php
@@ -1,0 +1,124 @@
+<?php
+
+use FP\PerfSuite\Services\DB\Cleaner;
+use FP\PerfSuite\Utils\Env;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/bootstrap.php';
+
+class DummyWpdb
+{
+    public string $posts = 'wp_posts';
+    public string $comments = 'wp_comments';
+    public string $options = 'wp_options';
+    public string $postmeta = 'wp_postmeta';
+    public string $termmeta = 'wp_termmeta';
+    public string $terms = 'wp_terms';
+    public string $usermeta = 'wp_usermeta';
+    public string $users = 'wp_users';
+    public array $queries = [];
+
+    public function prepare(string $query, ...$args): string
+    {
+        if (isset($args[0]) && is_array($args[0])) {
+            $args = $args[0];
+        }
+        $formatted = [];
+        foreach ($args as $arg) {
+            if (is_numeric($arg)) {
+                $formatted[] = (int) $arg;
+            } else {
+                $formatted[] = "'" . $arg . "'";
+            }
+        }
+        $query = preg_replace('/%d/', '%s', $query);
+        return vsprintf($query, $formatted);
+    }
+
+    public function get_col(string $query): array
+    {
+        $this->queries[] = $query;
+        if (strpos($query, 'FROM wp_posts') !== false) {
+            return [1, 2];
+        }
+        if (strpos($query, 'FROM wp_comments') !== false) {
+            return [3];
+        }
+        if (strpos($query, 'wp_options') !== false) {
+            return ['_transient_timeout_test'];
+        }
+        if (strpos($query, 'wp_postmeta') !== false) {
+            return [5];
+        }
+        if (strpos($query, 'SHOW TABLES') !== false) {
+            return ['wp_posts', 'wp_options'];
+        }
+        return [];
+    }
+
+    public function query(string $query): int
+    {
+        $this->queries[] = $query;
+        return 1;
+    }
+
+    public function get_results(string $query): array
+    {
+        if (strpos($query, 'SHOW TABLE STATUS') !== false) {
+            return [(object) ['Data_free' => 1024], (object) ['Data_free' => 2048]];
+        }
+        return [];
+    }
+}
+
+final class CleanerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $GLOBALS['wpdb'] = new DummyWpdb();
+        $GLOBALS['__hooks'] = [];
+        $GLOBALS['__cron'] = [];
+        $GLOBALS['__wp_options'] = [];
+    }
+
+    public function testCleanupDryRun(): void
+    {
+        $cleaner = new Cleaner(new Env());
+        $result = $cleaner->cleanup(['revisions', 'spam_comments'], true, 100);
+        $this->assertSame(2, $result['revisions']['found']);
+        $this->assertSame(0, $result['revisions']['deleted']);
+        $this->assertSame(1, $result['spam_comments']['found']);
+    }
+
+    public function testCleanupDeletesWhenNotDryRun(): void
+    {
+        $cleaner = new Cleaner(new Env());
+        $result = $cleaner->cleanup(['revisions'], false, 50);
+        $this->assertSame(2, $result['revisions']['deleted']);
+    }
+
+    public function testOverheadCalculation(): void
+    {
+        $cleaner = new Cleaner(new Env());
+        $overhead = $cleaner->overhead();
+        $this->assertGreaterThan(0, $overhead);
+    }
+
+    public function testPrimeSchedulesAddsIntervalsOnce(): void
+    {
+        $cleaner = new Cleaner(new Env());
+        $cleaner->primeSchedules();
+
+        $schedules = apply_filters('cron_schedules', []);
+        $this->assertArrayHasKey('fp_ps_weekly', $schedules);
+        $this->assertArrayHasKey('fp_ps_monthly', $schedules);
+        $this->assertTrue(has_filter('cron_schedules', [$cleaner, 'registerSchedules']));
+
+        $before = count($GLOBALS['__hooks']['cron_schedules'] ?? []);
+        $cleaner->primeSchedules();
+        $after = count($GLOBALS['__hooks']['cron_schedules'] ?? []);
+
+        $this->assertSame($before, $after, 'Prime schedules should not duplicate callbacks.');
+    }
+}

--- a/fp-performance-suite/tests/ScorerTest.php
+++ b/fp-performance-suite/tests/ScorerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use FP\PerfSuite\Services\Assets\Optimizer;
+use FP\PerfSuite\Services\Cache\Headers;
+use FP\PerfSuite\Services\Cache\PageCache;
+use FP\PerfSuite\Services\DB\Cleaner;
+use FP\PerfSuite\Services\Logs\DebugToggler;
+use FP\PerfSuite\Services\Media\WebPConverter;
+use FP\PerfSuite\Services\Score\Scorer;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/bootstrap.php';
+
+final class ScorerTest extends TestCase
+{
+    public function testScoreWithAllOptimizations(): void
+    {
+        $pageCache = $this->createConfiguredMock(PageCache::class, ['isEnabled' => true, 'status' => ['enabled' => true]]);
+        $headers = $this->createConfiguredMock(Headers::class, ['status' => ['enabled' => true, 'headers' => []]]);
+        $optimizer = $this->createConfiguredMock(Optimizer::class, ['status' => ['minify_html' => true, 'defer_js' => true, 'async_js' => false, 'remove_emojis' => true, 'heartbeat_admin' => 60]]);
+        $webp = $this->createConfiguredMock(WebPConverter::class, ['status' => ['enabled' => true, 'coverage' => 95.0]]);
+        $cleaner = $this->createConfiguredMock(Cleaner::class, ['status' => ['overhead_mb' => 2.0]]);
+        $debug = $this->createConfiguredMock(DebugToggler::class, ['status' => ['log_file' => '']]);
+
+        $scorer = new Scorer($pageCache, $headers, $optimizer, $webp, $cleaner, $debug);
+        $result = $scorer->calculate();
+        $this->assertSame(100, $result['total']);
+    }
+
+    public function testScoreSuggestsWhenDisabled(): void
+    {
+        $pageCache = $this->createConfiguredMock(PageCache::class, ['isEnabled' => false]);
+        $headers = $this->createConfiguredMock(Headers::class, ['status' => ['enabled' => false, 'headers' => []]]);
+        $optimizer = $this->createConfiguredMock(Optimizer::class, ['status' => ['minify_html' => false, 'defer_js' => false, 'async_js' => false, 'remove_emojis' => false, 'heartbeat_admin' => 30]]);
+        $webp = $this->createConfiguredMock(WebPConverter::class, ['status' => ['enabled' => false, 'coverage' => 10.0]]);
+        $cleaner = $this->createConfiguredMock(Cleaner::class, ['status' => ['overhead_mb' => 30.0]]);
+        $debug = $this->createConfiguredMock(DebugToggler::class, ['status' => ['log_file' => __FILE__]]);
+
+        $scorer = new Scorer($pageCache, $headers, $optimizer, $webp, $cleaner, $debug);
+        $result = $scorer->calculate();
+        $this->assertLessThan(60, $result['total']);
+        $this->assertNotEmpty($result['suggestions']);
+    }
+}

--- a/fp-performance-suite/tests/bootstrap.php
+++ b/fp-performance-suite/tests/bootstrap.php
@@ -1,0 +1,170 @@
+<?php
+
+define('ABSPATH', __DIR__ . '/../');
+
+define('WP_CONTENT_DIR', __DIR__ . '/../wp-content');
+
+if (!defined('HOUR_IN_SECONDS')) {
+    define('HOUR_IN_SECONDS', 3600);
+}
+if (!defined('DAY_IN_SECONDS')) {
+    define('DAY_IN_SECONDS', 86400);
+}
+if (!defined('WEEK_IN_SECONDS')) {
+    define('WEEK_IN_SECONDS', 604800);
+}
+
+if (!function_exists('__')) {
+    function __($text, $domain = null)
+    {
+        return $text;
+    }
+}
+
+if (!function_exists('add_action')) {
+    function add_action($hook, $callback, $priority = 10, $accepted_args = 1)
+    {
+        $GLOBALS['__hooks'][$hook][] = $callback;
+    }
+}
+
+if (!function_exists('add_filter')) {
+    function add_filter($hook, $callback, $priority = 10, $accepted_args = 1)
+    {
+        add_action($hook, $callback, $priority, $accepted_args);
+    }
+}
+
+if (!function_exists('has_filter')) {
+    function has_filter($hook, $callback = false)
+    {
+        if (empty($GLOBALS['__hooks'][$hook])) {
+            return false;
+        }
+        if (false === $callback) {
+            return true;
+        }
+        foreach ($GLOBALS['__hooks'][$hook] as $registered) {
+            if ($registered === $callback) {
+                return true;
+            }
+        }
+        return false;
+    }
+}
+
+if (!function_exists('apply_filters')) {
+    function apply_filters($hook, $value)
+    {
+        if (!empty($GLOBALS['__hooks'][$hook])) {
+            foreach ($GLOBALS['__hooks'][$hook] as $callback) {
+                $value = call_user_func($callback, $value);
+            }
+        }
+        return $value;
+    }
+}
+
+if (!function_exists('esc_html__')) {
+    function esc_html__($text, $domain = null)
+    {
+        return $text;
+    }
+}
+
+if (!function_exists('wp_parse_args')) {
+    function wp_parse_args($args, $defaults = [])
+    {
+        return array_merge($defaults, $args);
+    }
+}
+
+if (!function_exists('sanitize_key')) {
+    function sanitize_key($key)
+    {
+        return preg_replace('/[^a-z0-9_\-]/', '', strtolower($key));
+    }
+}
+
+if (!function_exists('sanitize_text_field')) {
+    function sanitize_text_field($text)
+    {
+        return trim((string) $text);
+    }
+}
+
+if (!function_exists('update_option')) {
+    function update_option($name, $value)
+    {
+        $GLOBALS['__wp_options'][$name] = $value;
+        return true;
+    }
+}
+
+if (!function_exists('get_option')) {
+    function get_option($name, $default = false)
+    {
+        return $GLOBALS['__wp_options'][$name] ?? $default;
+    }
+}
+
+if (!function_exists('has_action')) {
+    function has_action($hook, $callback = false)
+    {
+        return has_filter($hook, $callback);
+    }
+}
+
+if (!function_exists('wp_json_encode')) {
+    function wp_json_encode($data, $flags = 0)
+    {
+        return json_encode($data, $flags);
+    }
+}
+
+if (!function_exists('delete_transient')) {
+    function delete_transient($name)
+    {
+        unset($GLOBALS['__transients'][$name]);
+    }
+}
+
+if (!function_exists('wp_schedule_event')) {
+    function wp_schedule_event($timestamp, $recurrence, $hook)
+    {
+        $GLOBALS['__cron'][$hook] = ['timestamp' => $timestamp, 'recurrence' => $recurrence];
+        return true;
+    }
+}
+
+if (!function_exists('wp_next_scheduled')) {
+    function wp_next_scheduled($hook)
+    {
+        return isset($GLOBALS['__cron'][$hook]) ? $GLOBALS['__cron'][$hook]['timestamp'] : false;
+    }
+}
+
+if (!function_exists('wp_clear_scheduled_hook')) {
+    function wp_clear_scheduled_hook($hook)
+    {
+        unset($GLOBALS['__cron'][$hook]);
+    }
+}
+
+if (!function_exists('number_format_i18n')) {
+    function number_format_i18n($number, $decimals = 0)
+    {
+        return number_format($number, $decimals);
+    }
+}
+
+require_once __DIR__ . '/../src/Services/Cache/PageCache.php';
+require_once __DIR__ . '/../src/Services/Cache/Headers.php';
+require_once __DIR__ . '/../src/Services/Assets/Optimizer.php';
+require_once __DIR__ . '/../src/Services/Media/WebPConverter.php';
+require_once __DIR__ . '/../src/Services/DB/Cleaner.php';
+require_once __DIR__ . '/../src/Services/Score/Scorer.php';
+require_once __DIR__ . '/../src/Utils/Fs.php';
+require_once __DIR__ . '/../src/Utils/Htaccess.php';
+require_once __DIR__ . '/../src/Utils/Env.php';
+require_once __DIR__ . '/../src/Utils/Semaphore.php';

--- a/fp-performance-suite/uninstall.php
+++ b/fp-performance-suite/uninstall.php
@@ -1,0 +1,22 @@
+<?php
+
+if (!defined('WP_UNINSTALL_PLUGIN')) {
+    exit;
+}
+
+$optionKeys = [
+    'fp_ps_page_cache',
+    'fp_ps_browser_cache',
+    'fp_ps_assets',
+    'fp_ps_webp',
+    'fp_ps_db',
+    'fp_ps_settings',
+    'fp_ps_preset',
+    'fp_ps_critical_css',
+];
+
+foreach ($optionKeys as $key) {
+    delete_option($key);
+}
+
+delete_option('fp_perfsuite_version');

--- a/fp-performance-suite/views/admin-page.php
+++ b/fp-performance-suite/views/admin-page.php
@@ -1,0 +1,23 @@
+<?php
+/** @var array<string, mixed> $pageData */
+$title = $pageData['title'] ?? '';
+$content = $pageData['content'] ?? '';
+$breadcrumbs = $pageData['breadcrumbs'] ?? [];
+?>
+<div class="fp-ps-wrap">
+    <header class="fp-ps-header">
+        <h1><?php echo esc_html($title); ?></h1>
+        <?php if (!empty($breadcrumbs)) : ?>
+            <nav class="fp-ps-breadcrumbs" aria-label="Breadcrumb">
+                <ol>
+                    <?php foreach ($breadcrumbs as $crumb) : ?>
+                        <li><?php echo esc_html($crumb); ?></li>
+                    <?php endforeach; ?>
+                </ol>
+            </nav>
+        <?php endif; ?>
+    </header>
+    <main class="fp-ps-content">
+        <?php echo $content; // already escaped/sanitized within content provider ?>
+    </main>
+</div>


### PR DESCRIPTION
## Summary
- ensure the database cleaner primes its cron schedules before scheduling events, including during plugin activation
- extend the test bootstrap and cleaner unit test to verify the custom intervals are registered once
- update the build tracker to mark the hardening phase complete

## Testing
- not run (phpunit unavailable)


------
https://chatgpt.com/codex/tasks/task_e_68dc22b1ad28832fa06cd3af0ccf42cb